### PR TITLE
Improve anchor position handling

### DIFF
--- a/Animations/src/main/java/io/doist/recyclerviewext/animations/WithLayerItemAnimator.java
+++ b/Animations/src/main/java/io/doist/recyclerviewext/animations/WithLayerItemAnimator.java
@@ -78,6 +78,14 @@ public class WithLayerItemAnimator extends RecyclerView.ItemAnimator {
         }
     }
 
+    public WithLayerItemAnimator() {
+        super();
+    }
+
+    public WithLayerItemAnimator(boolean supportsChangingAnimations) {
+        setSupportsChangeAnimations(supportsChangingAnimations);
+    }
+
     @Override
     public void runPendingAnimations() {
         boolean removalsPending = !mPendingRemovals.isEmpty();

--- a/DragDrop/build.gradle
+++ b/DragDrop/build.gradle
@@ -13,6 +13,5 @@ android {
 }
 
 dependencies {
-    // TODO: When updating, look for TODO in DragDropManager and remove the try / catch.
-    compile 'com.android.support:recyclerview-v7:22.2.1'
+    compile 'com.android.support:recyclerview-v7:22.2.1' // Check DragDropManager when updating.
 }

--- a/DragDrop/src/main/java/io/doist/recyclerviewext/dragdrop/DragDropManager.java
+++ b/DragDrop/src/main/java/io/doist/recyclerviewext/dragdrop/DragDropManager.java
@@ -650,32 +650,32 @@ public class DragDropManager<VH extends RecyclerView.ViewHolder, T extends Recyc
      * Swaps the dragged position in the wrapper adapter whenever it overlaps at least half of another position.
      */
     private void handleSwap() {
-        ViewInfo swap = null;
+        View swapView = null;
 
         if (mLayoutOrientation == LinearLayoutManager.HORIZONTAL) {
-            ViewInfo left = findChildViewUnder(mItemLocation.left, mItemLocation.centerY());
-            if (left != null && mItemLocation.left < (left.view.getLeft() + left.view.getRight()) / 2f) {
-                swap = left;
+            View leftView = findChildViewUnder(mItemLocation.left, mItemLocation.centerY());
+            if (leftView != null && mItemLocation.left < (leftView.getLeft() + leftView.getRight()) / 2f) {
+                swapView = leftView;
             } else {
-                ViewInfo right = findChildViewUnder(mItemLocation.right, mItemLocation.centerY());
-                if (right != null && mItemLocation.right > (right.view.getLeft() + right.view.getRight()) / 2f) {
-                    swap = right;
+                View rightView = findChildViewUnder(mItemLocation.right, mItemLocation.centerY());
+                if (rightView != null && mItemLocation.right > (rightView.getLeft() + rightView.getRight()) / 2f) {
+                    swapView = rightView;
                 }
             }
         } else {
-            ViewInfo top = findChildViewUnder(mItemLocation.centerX(), mItemLocation.top);
-            if (top != null && mItemLocation.top < (top.view.getTop() + top.view.getBottom()) / 2f) {
-                swap = top;
+            View topView = findChildViewUnder(mItemLocation.centerX(), mItemLocation.top);
+            if (topView != null && mItemLocation.top < (topView.getTop() + topView.getBottom()) / 2f) {
+                swapView = topView;
             } else {
-                ViewInfo bottom = findChildViewUnder(mItemLocation.centerX(), mItemLocation.bottom);
-                if (bottom != null && mItemLocation.bottom > (bottom.view.getTop() + bottom.view.getBottom()) / 2f) {
-                    swap = bottom;
+                View bottomView = findChildViewUnder(mItemLocation.centerX(), mItemLocation.bottom);
+                if (bottomView != null && mItemLocation.bottom > (bottomView.getTop() + bottomView.getBottom()) / 2f) {
+                    swapView = bottomView;
                 }
             }
         }
 
-        if (swap != null) {
-            int swapPosition = mRecyclerView.getChildLayoutPosition(swap.view);
+        if (swapView != null) {
+            int swapPosition = mRecyclerView.getChildLayoutPosition(swapView);
             if (swapPosition != RecyclerView.NO_POSITION) {
                 mDragDropAdapter.setCurrentPosition(swapPosition);
             }
@@ -686,17 +686,14 @@ public class DragDropManager<VH extends RecyclerView.ViewHolder, T extends Recyc
      * Similar to {@link RecyclerView#findChildViewUnder(float, float)}, but only considers visible children and
      * disregards translation values.
      */
-    private ViewInfo mViewInfo = new ViewInfo();
-    private ViewInfo findChildViewUnder(float x, float y) {
+    private View findChildViewUnder(float x, float y) {
         final int count = mLayoutManager.getChildCount();
         for (int i = count - 1; i >= 0; i--) {
             final View child = mLayoutManager.getChildAt(i);
             if (child.getVisibility() == View.VISIBLE
                     && x >= child.getLeft() && x <= child.getRight()
                     && y >= child.getTop() && y <= child.getBottom()) {
-                mViewInfo.view = child;
-                mViewInfo.start = i == 0;
-                return mViewInfo;
+                return child;
             }
         }
         return null;
@@ -815,9 +812,9 @@ public class DragDropManager<VH extends RecyclerView.ViewHolder, T extends Recyc
                 mScheduled = false;
 
                 int position = RecyclerView.NO_POSITION;
-                ViewInfo info = findChildViewUnder(mItemLocation.centerX(), mItemLocation.centerY());
-                if (info != null) {
-                    position = mRecyclerView.getChildLayoutPosition(info.view);
+                View view = findChildViewUnder(mItemLocation.centerX(), mItemLocation.centerY());
+                if (view != null) {
+                    position = mRecyclerView.getChildLayoutPosition(view);
                 }
                 if (position == RecyclerView.NO_POSITION) {
                     position = mAdapter.getItemCount() - 1;
@@ -882,13 +879,5 @@ public class DragDropManager<VH extends RecyclerView.ViewHolder, T extends Recyc
             mRecyclerView.invalidate(mItemLocation);
             mRecyclerView.postOnAnimation(this);
         }
-    }
-
-    /**
-     * Reused in every {@link #findChildViewUnder(float, float)} call.
-     */
-    private static class ViewInfo {
-        public View view;
-        public boolean start;
     }
 }

--- a/DragDrop/src/main/java/io/doist/recyclerviewext/dragdrop/DragDropManager.java
+++ b/DragDrop/src/main/java/io/doist/recyclerviewext/dragdrop/DragDropManager.java
@@ -41,7 +41,7 @@ public class DragDropManager<VH extends RecyclerView.ViewHolder, T extends Recyc
         extends RecyclerView.ItemDecoration implements RecyclerView.OnItemTouchListener {
     public static final String LOG_TAG = DragDropManager.class.getSimpleName();
 
-    private static final float SCROLL_SPEED_MAX_DP = 16;
+    private static final float SCROLL_SPEED_MAX_DP = 12;
     private static final int SETTLE_DURATION_MS = 250;
 
     private RecyclerView mRecyclerView;

--- a/DragDrop/src/main/java/io/doist/recyclerviewext/dragdrop/DragDropManager.java
+++ b/DragDrop/src/main/java/io/doist/recyclerviewext/dragdrop/DragDropManager.java
@@ -512,11 +512,7 @@ public class DragDropManager<VH extends RecyclerView.ViewHolder, T extends Recyc
         }
 
         if (scrollByX > 0 || scrollByY > 0) {
-            try {
-                mRecyclerView.scrollBy(scrollByX * direction, scrollByY * direction);
-            } catch (NullPointerException e) {
-                // TODO: Remove this when RV is updated: https://code.google.com/p/android/issues/detail?id=174981
-            }
+            mRecyclerView.scrollBy(scrollByX * direction, scrollByY * direction);
 
             // Stack from end if needed to ensure anchor position is reversed and never swapped,
             // which causes glitches. Ref: https://code.google.com/p/android/issues/detail?id=99047

--- a/Samples/build.gradle
+++ b/Samples/build.gradle
@@ -19,7 +19,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:22.0.0'
+    compile 'com.android.support:appcompat-v7:22.2.1'
 
     compile project(':Animations')
     compile project(':ClickListeners')

--- a/Samples/src/main/java/io/doist/recyclerviewext/demo/DemoActivity.java
+++ b/Samples/src/main/java/io/doist/recyclerviewext/demo/DemoActivity.java
@@ -47,7 +47,8 @@ public class DemoActivity extends ActionBarActivity {
         mContainer = (ViewGroup) findViewById(R.id.container);
         mRecyclerView = (RecyclerView) findViewById(R.id.recycler_view);
         mRecyclerView.setHasFixedSize(true);
-        mRecyclerView.setLayoutManager(new LinearLayoutManager(this));
+        mLinearLayoutManager = new LinearLayoutManager(this);
+        mRecyclerView.setLayoutManager(mLinearLayoutManager);
         mRecyclerView.addItemDecoration(new DividerItemDecoration(this, R.drawable.divider_light, true));
         mAdapter = new DemoAdapter(false);
         mProgressEmptyRecyclerFlipper =

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.3'
+        classpath 'com.android.tools.build:gradle:1.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-all.zip


### PR DESCRIPTION
There are some glitches when dragging up in the list. The reason for this is that `RecyclerView` uses position 0 as its anchor position, and when it's messed with (ie. swapping while scrolling) everything goes  haywire. This PR improves this by swapping `stackFromEnd` when scrolling up or down, and restoring its original value in the end.

Current shortcomings:
- The way [we currently maintain the position](https://github.com/Doist/RecyclerViewExtensions/blob/fix.anchor_position/DragDrop/src/main/java/io/doist/recyclerviewext/dragdrop/DragDropManager.java#L670) when swapping `stackFromEnd` is undocumented. The documented approach doesn't work :confused: 
- There are still glitches if the list entry is taller than the list itself. To fix this, we'd have to redo the whole logic behind swapping / scrolling to use the touch position instead of the dragged item's position. This is complex and mostly unnecessary, so I suggest we ignore this for now.