### PR TITLE
Check if sticky header is valid before reattaching

### DIFF
--- a/StickyHeaders/src/main/java/io/doist/recyclerviewext/sticky_headers/StickyHeadersLinearLayoutManager.java
+++ b/StickyHeaders/src/main/java/io/doist/recyclerviewext/sticky_headers/StickyHeadersLinearLayoutManager.java
@@ -192,7 +192,12 @@ public class StickyHeadersLinearLayoutManager<T extends RecyclerView.Adapter & S
 
     private void attachStickyHeader() {
         if (mStickyHeader != null) {
-            attachView(mStickyHeader);
+            RecyclerView.LayoutParams rlp = (RecyclerView.LayoutParams) mStickyHeader.getLayoutParams();
+            // Check if the view is still valid. This prevents
+            // https://fabric.io/doist/android/apps/com.todoist/issues/562b0832f5d3a7f76b08e19f
+            if (!rlp.isViewInvalid()) {
+                attachView(mStickyHeader);
+            }
         }
     }
 


### PR DESCRIPTION
This PR should fix following crash:
https://fabric.io/doist/android/apps/com.todoist/issues/562b0832f5d3a7f76b08e19f

Unfortunately I couldn't reproduce nor find the reason for this crash but at least there is a way to prevent it.

The exception is thrown when
```
vh = stickyHeader.getLayoutParams().mViewHolder;
if (!vh.isTmpDetached() && !vh.shouldIgnore())
throw new IllegalArgumentException("Called attach on a child which is not" + " detached: " + vh);
```
but mViewHolder is not public so we cannot run the same check before reattaching the view :disappointed: 

The crash message is:
> Called attach on a child which is not detached: ViewHolder{76c1c83 position=-1 id=-1, oldPos=-1, pLpos:-1 **invalid** unboundundefined adapter position no parent}

which tells us that every time the crash happens `viewHolder.isInvalid()` is true so checking for this flag should indirectly prevent the crash. In normal case scenario this flag should be set to false.


