### PR TITLE
Adjust scroll for sticky header

### DIFF
--- a/StickyHeaders/src/main/java/io/doist/recyclerviewext/sticky_headers/StickyHeadersLinearLayoutManager.java
+++ b/StickyHeaders/src/main/java/io/doist/recyclerviewext/sticky_headers/StickyHeadersLinearLayoutManager.java
@@ -2,6 +2,8 @@ package io.doist.recyclerviewext.sticky_headers;
 
 import android.content.Context;
 import android.graphics.PointF;
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.LinearLayoutManager;
@@ -84,6 +86,30 @@ public class StickyHeadersLinearLayoutManager<T extends RecyclerView.Adapter & S
             mAdapter = null;
             mHeaderPositions.clear();
         }
+    }
+
+    @Override
+    public Parcelable onSaveInstanceState() {
+        Parcelable superState = super.onSaveInstanceState();
+
+        SavedState ss = new SavedState();
+        ss.superState = superState;
+        ss.pendingScrollPosition = mPendingScrollPosition;
+        ss.pendingScrollOffset = mPendingScrollOffset;
+
+        return ss;
+    }
+
+    @Override
+    public void onRestoreInstanceState(Parcelable state) {
+        if (state instanceof SavedState) {
+            SavedState ss = (SavedState) state;
+            mPendingScrollPosition = ss.pendingScrollPosition;
+            mPendingScrollOffset = ss.pendingScrollOffset;
+            state = ss.superState;
+        }
+
+        super.onRestoreInstanceState(state);
     }
 
     @Override
@@ -665,5 +691,44 @@ public class StickyHeadersLinearLayoutManager<T extends RecyclerView.Adapter & S
                 mHeaderPositions.add(headerPos);
             }
         }
+    }
+
+    public static class SavedState implements Parcelable {
+        private Parcelable superState;
+        private int pendingScrollPosition;
+        private int pendingScrollOffset;
+
+        public SavedState() {
+        }
+
+        public SavedState(Parcel in) {
+            superState = in.readParcelable(StickyHeadersLinearLayoutManager.class.getClassLoader());
+            pendingScrollPosition = in.readInt();
+            pendingScrollOffset = in.readInt();
+        }
+
+        @Override
+        public int describeContents() {
+            return 0;
+        }
+
+        @Override
+        public void writeToParcel(@NonNull Parcel dest, int flags) {
+            dest.writeParcelable(superState, flags);
+            dest.writeInt(pendingScrollPosition);
+            dest.writeInt(pendingScrollOffset);
+        }
+
+        public static final Parcelable.Creator<SavedState> CREATOR = new Parcelable.Creator<SavedState>() {
+            @Override
+            public SavedState createFromParcel(Parcel in) {
+                return new SavedState(in);
+            }
+
+            @Override
+            public SavedState[] newArray(int size) {
+                return new SavedState[size];
+            }
+        };
     }
 }

--- a/StickyHeaders/src/main/java/io/doist/recyclerviewext/sticky_headers/StickyHeadersLinearLayoutManager.java
+++ b/StickyHeaders/src/main/java/io/doist/recyclerviewext/sticky_headers/StickyHeadersLinearLayoutManager.java
@@ -160,6 +160,9 @@ public class StickyHeadersLinearLayoutManager<T extends RecyclerView.Adapter & S
     }
 
     public void scrollToPositionWithOffset(int position, int offset, boolean adjustForStickyHeader) {
+        // Reset pending scroll.
+        setPendingScroll(RecyclerView.NO_POSITION, 0);
+
         // Adjusting is disabled.
         if (!adjustForStickyHeader) {
             super.scrollToPositionWithOffset(position, offset);
@@ -181,15 +184,12 @@ public class StickyHeadersLinearLayoutManager<T extends RecyclerView.Adapter & S
 
         // Current sticky header is the same as at the position. Adjust the scroll offset and reset pending scroll.
         if (mStickyHeader != null && headerIndex == findHeaderIndex(mStickyHeaderPosition)) {
-            mPendingScrollPosition = RecyclerView.NO_POSITION;
-            mPendingScrollOffset = 0;
             super.scrollToPositionWithOffset(position, offset + mStickyHeader.getHeight());
             return;
         }
 
         // Remember this position and offset and scroll to it to trigger creating the sticky header.
-        mPendingScrollPosition = position;
-        mPendingScrollOffset = offset;
+        setPendingScroll(position, offset);
         super.scrollToPositionWithOffset(position, offset);
     }
 
@@ -381,6 +381,7 @@ public class StickyHeadersLinearLayoutManager<T extends RecyclerView.Adapter & S
 
                     if (mPendingScrollPosition != RecyclerView.NO_POSITION) {
                         scrollToPositionWithOffset(mPendingScrollPosition, mPendingScrollOffset);
+                        setPendingScroll(RecyclerView.NO_POSITION, 0);
                     }
                 }
             });
@@ -573,6 +574,11 @@ public class StickyHeadersLinearLayoutManager<T extends RecyclerView.Adapter & S
             }
         }
         return -1;
+    }
+
+    private void setPendingScroll(int position, int offset) {
+        mPendingScrollPosition = position;
+        mPendingScrollOffset = offset;
     }
 
     /**

--- a/StickyHeaders/src/main/java/io/doist/recyclerviewext/sticky_headers/StickyHeadersLinearLayoutManager.java
+++ b/StickyHeaders/src/main/java/io/doist/recyclerviewext/sticky_headers/StickyHeadersLinearLayoutManager.java
@@ -90,13 +90,10 @@ public class StickyHeadersLinearLayoutManager<T extends RecyclerView.Adapter & S
 
     @Override
     public Parcelable onSaveInstanceState() {
-        Parcelable superState = super.onSaveInstanceState();
-
         SavedState ss = new SavedState();
-        ss.superState = superState;
+        ss.superState = super.onSaveInstanceState();
         ss.pendingScrollPosition = mPendingScrollPosition;
         ss.pendingScrollOffset = mPendingScrollOffset;
-
         return ss;
     }
 

--- a/StickyHeaders/src/main/java/io/doist/recyclerviewext/sticky_headers/StickyHeadersLinearLayoutManager.java
+++ b/StickyHeaders/src/main/java/io/doist/recyclerviewext/sticky_headers/StickyHeadersLinearLayoutManager.java
@@ -708,7 +708,7 @@ public class StickyHeadersLinearLayoutManager<T extends RecyclerView.Adapter & S
         }
 
         public SavedState(Parcel in) {
-            superState = in.readParcelable(StickyHeadersLinearLayoutManager.class.getClassLoader());
+            superState = in.readParcelable(SavedState.class.getClassLoader());
             pendingScrollPosition = in.readInt();
             pendingScrollOffset = in.readInt();
         }


### PR DESCRIPTION
This PR changes the behavior of `scrollToPositionWithOffset` to, by default, adjust the scroll offset to account for the sticky header. After scrolling, the whole item should be visible, instead of being covered by the sticky header.