### PR TITLE
Correct item count value

### DIFF
--- a/Flippers/src/main/java/io/doist/recyclerviewext/flippers/EmptyRecyclerFlipper.java
+++ b/Flippers/src/main/java/io/doist/recyclerviewext/flippers/EmptyRecyclerFlipper.java
@@ -79,20 +79,21 @@ public class EmptyRecyclerFlipper extends Flipper {
     private class EmptyAdapterDataObserver extends RecyclerView.AdapterDataObserver {
         @Override
         public void onChanged() {
-            checkCount(mAdapter.getItemCount());
+            checkCount();
         }
 
         @Override
         public void onItemRangeInserted(int positionStart, int itemCount) {
-            checkCount(mCount + itemCount);
+            checkCount();
         }
 
         @Override
         public void onItemRangeRemoved(int positionStart, int itemCount) {
-            checkCount(mCount - itemCount);
+            checkCount();
         }
 
-        private void checkCount(int count) {
+        private void checkCount() {
+            int count = mAdapter.getItemCount();
             if (count == 0 && mCount > 0) {
                 replace(mRecyclerView, mEmptyView);
             } else if(count > 0 && mCount == 0) {


### PR DESCRIPTION
This PR changes how we check for the number of items in the adapter.

It is possible that during data update, `mCount - itemCount` is 0 and the empty view is shown. In fact, it is just a temporary state and the real number of items is different.

Checking for `#getItemCount()` fixes this issue.