### PR TITLE
Drag & drop anywhere, plus fixes

### DIFF
--- a/Animations/build.gradle
+++ b/Animations/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    buildToolsVersion "29.0.2"
 
     defaultConfig {
         minSdkVersion 16
@@ -13,5 +13,6 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.recyclerview:recyclerview:1.0.0' // Check WithLayerItemAnimator when updating.
+    // Check WithLayerItemAnimator when updating.
+    implementation "androidx.recyclerview:recyclerview:1.0.0"
 }

--- a/Animations/src/main/java/io/doist/recyclerviewext/animations/AdapterNotifyDiffHandler.java
+++ b/Animations/src/main/java/io/doist/recyclerviewext/animations/AdapterNotifyDiffHandler.java
@@ -7,7 +7,7 @@ import androidx.recyclerview.widget.RecyclerView;
  * It is expected that the associated data set changes have already been submitted.
  */
 class AdapterNotifyDiffHandler implements DiffHandler {
-    private RecyclerView.Adapter adapter;
+    private final RecyclerView.Adapter adapter;
 
     AdapterNotifyDiffHandler(RecyclerView.Adapter adapter) {
         this.adapter = adapter;

--- a/Animations/src/main/java/io/doist/recyclerviewext/animations/AsyncDataSetDiffer.java
+++ b/Animations/src/main/java/io/doist/recyclerviewext/animations/AsyncDataSetDiffer.java
@@ -18,11 +18,11 @@ import androidx.recyclerview.widget.RecyclerView;
  * @see DataSetDiffer
  */
 public class AsyncDataSetDiffer {
-    private Handler handler = new Handler(Looper.getMainLooper());
-    private Executor executor = new LatestTaskAsyncTaskExecutor();
+    private final Handler handler = new Handler(Looper.getMainLooper());
+    private final Executor executor = new LatestTaskAsyncTaskExecutor();
 
-    private RecyclerView.Adapter adapter;
-    private DataSetDiffer dataSetDiffer;
+    private final RecyclerView.Adapter adapter;
+    private final DataSetDiffer dataSetDiffer;
     private int runningDiffCount = 0;
 
     /**

--- a/Animations/src/main/java/io/doist/recyclerviewext/animations/OpDiffHandler.java
+++ b/Animations/src/main/java/io/doist/recyclerviewext/animations/OpDiffHandler.java
@@ -9,7 +9,7 @@ import androidx.recyclerview.widget.RecyclerView;
  * Diff handler that keeps track of necessary operations to change the old data set into the new data set.
  */
 class OpDiffHandler implements DiffHandler {
-    private List<Op> ops = new LinkedList<>();
+    private final List<Op> ops = new LinkedList<>();
 
     public List<Op> getOps() {
         return ops;
@@ -46,8 +46,8 @@ class OpDiffHandler implements DiffHandler {
         public abstract void notify(RecyclerView.Adapter adapter);
 
         static class Change extends Op {
-            private int positionStart;
-            private int itemCount;
+            private final int positionStart;
+            private final int itemCount;
 
             Change(int positionStart, int itemCount) {
                 this.positionStart = positionStart;
@@ -61,8 +61,8 @@ class OpDiffHandler implements DiffHandler {
         }
 
         static class Insert extends Op {
-            private int positionStart;
-            private int itemCount;
+            private final int positionStart;
+            private final int itemCount;
 
             Insert(int positionStart, int itemCount) {
                 this.positionStart = positionStart;
@@ -76,8 +76,8 @@ class OpDiffHandler implements DiffHandler {
         }
 
         static class Remove extends Op {
-            private int positionStart;
-            private int itemCount;
+            private final int positionStart;
+            private final int itemCount;
 
             Remove(int positionStart, int itemCount) {
                 this.positionStart = positionStart;
@@ -91,8 +91,8 @@ class OpDiffHandler implements DiffHandler {
         }
 
         static class Move extends Op {
-            private int fromPosition;
-            private int toPosition;
+            private final int fromPosition;
+            private final int toPosition;
 
             Move(int fromPosition, int toPosition) {
                 this.fromPosition = fromPosition;

--- a/Animations/src/main/java/io/doist/recyclerviewext/animations/WithLayerItemAnimator.java
+++ b/Animations/src/main/java/io/doist/recyclerviewext/animations/WithLayerItemAnimator.java
@@ -279,7 +279,7 @@ public class WithLayerItemAnimator extends SimpleItemAnimator {
         if (deltaY != 0) {
             view.animate().withLayer().translationY(0);
         }
-        final ViewPropertyAnimator animation = view.animate().withLayer();
+        final ViewPropertyAnimator animation = view.animate();
         mMoveAnimations.add(holder);
         animation.setDuration(getMoveDuration()).setListener(new AnimatorListenerAdapter() {
             @Override

--- a/Animations/src/main/java/io/doist/recyclerviewext/animations/WithLayerItemAnimator.java
+++ b/Animations/src/main/java/io/doist/recyclerviewext/animations/WithLayerItemAnimator.java
@@ -28,23 +28,26 @@ import androidx.recyclerview.widget.SimpleItemAnimator;
 public class WithLayerItemAnimator extends SimpleItemAnimator {
     private static TimeInterpolator sDefaultInterpolator;
 
-    private ArrayList<ViewHolder> mPendingRemovals = new ArrayList<>();
-    private ArrayList<ViewHolder> mPendingAdditions = new ArrayList<>();
-    private ArrayList<MoveInfo> mPendingMoves = new ArrayList<>();
-    private ArrayList<ChangeInfo> mPendingChanges = new ArrayList<>();
+    private final ArrayList<ViewHolder> mPendingRemovals = new ArrayList<>();
+    private final ArrayList<ViewHolder> mPendingAdditions = new ArrayList<>();
+    private final ArrayList<MoveInfo> mPendingMoves = new ArrayList<>();
+    private final ArrayList<ChangeInfo> mPendingChanges = new ArrayList<>();
 
-    private ArrayList<ArrayList<ViewHolder>> mAdditionsList = new ArrayList<>();
-    private ArrayList<ArrayList<MoveInfo>> mMovesList = new ArrayList<>();
-    private ArrayList<ArrayList<ChangeInfo>> mChangesList = new ArrayList<>();
+    private final ArrayList<ArrayList<ViewHolder>> mAdditionsList = new ArrayList<>();
+    private final ArrayList<ArrayList<MoveInfo>> mMovesList = new ArrayList<>();
+    private final ArrayList<ArrayList<ChangeInfo>> mChangesList = new ArrayList<>();
 
-    private ArrayList<ViewHolder> mAddAnimations = new ArrayList<>();
-    private ArrayList<ViewHolder> mMoveAnimations = new ArrayList<>();
-    private ArrayList<ViewHolder> mRemoveAnimations = new ArrayList<>();
-    private ArrayList<ViewHolder> mChangeAnimations = new ArrayList<>();
+    private final ArrayList<ViewHolder> mAddAnimations = new ArrayList<>();
+    private final ArrayList<ViewHolder> mMoveAnimations = new ArrayList<>();
+    private final ArrayList<ViewHolder> mRemoveAnimations = new ArrayList<>();
+    private final ArrayList<ViewHolder> mChangeAnimations = new ArrayList<>();
 
     private static class MoveInfo {
-        public ViewHolder holder;
-        public int fromX, fromY, toX, toY;
+        public final ViewHolder holder;
+        public final int fromX;
+        public final int fromY;
+        public final int toX;
+        public final int toY;
 
         private MoveInfo(ViewHolder holder, int fromX, int fromY, int toX, int toY) {
             this.holder = holder;
@@ -72,6 +75,7 @@ public class WithLayerItemAnimator extends SimpleItemAnimator {
             this.toY = toY;
         }
 
+        @NonNull
         @Override
         public String toString() {
             return "ChangeInfo{" +
@@ -110,8 +114,7 @@ public class WithLayerItemAnimator extends SimpleItemAnimator {
         mPendingRemovals.clear();
         // Next, move stuff
         if (movesPending) {
-            final ArrayList<MoveInfo> moves = new ArrayList<>();
-            moves.addAll(mPendingMoves);
+            final ArrayList<MoveInfo> moves = new ArrayList<>(mPendingMoves);
             mMovesList.add(moves);
             mPendingMoves.clear();
             Runnable mover = new Runnable() {
@@ -134,8 +137,7 @@ public class WithLayerItemAnimator extends SimpleItemAnimator {
         }
         // Next, change stuff, to run in parallel with move animations
         if (changesPending) {
-            final ArrayList<ChangeInfo> changes = new ArrayList<>();
-            changes.addAll(mPendingChanges);
+            final ArrayList<ChangeInfo> changes = new ArrayList<>(mPendingChanges);
             mChangesList.add(changes);
             mPendingChanges.clear();
             Runnable changer = new Runnable() {
@@ -157,8 +159,7 @@ public class WithLayerItemAnimator extends SimpleItemAnimator {
         }
         // Next, add stuff
         if (additionsPending) {
-            final ArrayList<ViewHolder> additions = new ArrayList<>();
-            additions.addAll(mPendingAdditions);
+            final ArrayList<ViewHolder> additions = new ArrayList<>(mPendingAdditions);
             mAdditionsList.add(additions);
             mPendingAdditions.clear();
             Runnable adder = new Runnable() {

--- a/ClickListeners/build.gradle
+++ b/ClickListeners/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    buildToolsVersion "29.0.2"
 
     defaultConfig {
         minSdkVersion 16
@@ -13,5 +13,5 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.recyclerview:recyclerview:1.0.0'
+    implementation "androidx.recyclerview:recyclerview:1.0.0"
 }

--- a/Dividers/build.gradle
+++ b/Dividers/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    buildToolsVersion "29.0.2"
 
     defaultConfig {
         minSdkVersion 16
@@ -13,5 +13,5 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.recyclerview:recyclerview:1.0.0'
+    implementation "androidx.recyclerview:recyclerview:1.0.0"
 }

--- a/Dividers/src/main/java/io/doist/recyclerviewext/dividers/DividerItemDecoration.java
+++ b/Dividers/src/main/java/io/doist/recyclerviewext/dividers/DividerItemDecoration.java
@@ -8,6 +8,7 @@ import android.graphics.drawable.Drawable;
 import android.view.View;
 
 import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -89,7 +90,7 @@ public class DividerItemDecoration extends RecyclerView.ItemDecoration {
     }
 
     @Override
-    public void onDraw(Canvas canvas, RecyclerView parent, RecyclerView.State state) {
+    public void onDraw(@NonNull Canvas canvas, @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
         if (mVertical) {
             drawVertical(canvas, parent);
         } else {
@@ -148,7 +149,9 @@ public class DividerItemDecoration extends RecyclerView.ItemDecoration {
     }
 
     @Override
-    public void getItemOffsets(Rect outRect, View view, RecyclerView parent, RecyclerView.State state) {
+    public void getItemOffsets(
+            @NonNull Rect outRect, @NonNull View view, @NonNull RecyclerView parent,
+            @NonNull RecyclerView.State state) {
         if (!hasDivider(parent, view)) {
             outRect.set(0, 0, 0, 0);
         } else {

--- a/DragDrop/build.gradle
+++ b/DragDrop/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    buildToolsVersion "29.0.2"
 
     defaultConfig {
         minSdkVersion 16
@@ -13,5 +13,5 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.recyclerview:recyclerview:1.0.0' // Check DragDropHelper when updating.
+    implementation "androidx.recyclerview:recyclerview:1.0.0" // Check DragDropHelper when updating.
 }

--- a/DragDrop/src/main/java/io/doist/recyclerviewext/dragdrop/DragDropHelper.java
+++ b/DragDrop/src/main/java/io/doist/recyclerviewext/dragdrop/DragDropHelper.java
@@ -6,12 +6,12 @@ import android.util.Log;
 import android.util.TypedValue;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewConfiguration;
 import android.view.ViewParent;
-import android.view.animation.AccelerateInterpolator;
-import android.view.animation.Interpolator;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.math.MathUtils;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -20,15 +20,14 @@ import androidx.recyclerview.widget.RecyclerView;
  *
  * It works with {@link RecyclerView}, {@link LinearLayoutManager} and a {@link Callback}.
  *
- * Call {@link #start(RecyclerView.ViewHolder)} during or right before a motion event to start dragging that specific
- * {@link RecyclerView.ViewHolder}. Call {@link #stop()} to stop the ongoing drag at the current position.
+ * Call {@link #start(int)} during or right before a motion event to start dragging that specific position.
+ * Call {@link #stop()} to stop the ongoing drag at the current position.
  */
 public class DragDropHelper extends RecyclerView.ItemDecoration
-        implements RecyclerView.OnItemTouchListener, RecyclerView.ChildDrawingOrderCallback,
-                   RecyclerView.OnChildAttachStateChangeListener {
+        implements RecyclerView.OnItemTouchListener, RecyclerView.ChildDrawingOrderCallback {
     public static final String LOG_TAG = DragDropHelper.class.getSimpleName();
 
-    private static final float SCROLL_SPEED_MAX_DP = 12;
+    private static final float SCROLL_SPEED_MAX_DP = 16;
 
     /**
      * No drag is ongoing.
@@ -61,21 +60,20 @@ public class DragDropHelper extends RecyclerView.ItemDecoration
      */
     private static final int STATE_STOPPING = 5;
 
-    private static final Interpolator SCROLL_INTERPOLATOR = new AccelerateInterpolator();
-
     private RecyclerView mRecyclerView;
     private LinearLayoutManager mLayoutManager;
+    private RecyclerView.Adapter mAdapter;
     private Callback mCallback;
 
     /**
-     * {@link RecyclerView.ViewHolder} currently being dragged.
+     * The position/view holder currently being dragged.
      */
-    private RecyclerView.ViewHolder mViewHolder;
+    private Tracker mTracker;
 
     /**
-     * Current state. Can be {@link #STATE_NONE}, {@link #STATE_STARTING}, {@link #STATE_TRACKING},
-     * {@link #STATE_DRAGGING} or {@link #STATE_RECOVERING}. For any of these except the first,
-     * {@link #mViewHolder} is not null.
+     * Current state.
+     * Can be {@link #STATE_NONE}, {@link #STATE_STARTING}, {@link #STATE_TRACKING}, {@link #STATE_DRAGGING}
+     * or {@link #STATE_RECOVERING}.
      */
     private int mState = STATE_NONE;
 
@@ -86,12 +84,34 @@ public class DragDropHelper extends RecyclerView.ItemDecoration
     private int mStartLeft;
     private int mStartTop;
 
+    /**
+     * Starting coordinates for the touch event.
+     */
     private int mTouchStartX;
     private int mTouchStartY;
+
+    /**
+     * Current coordinates for the touch event.
+     */
     private int mTouchCurrentX;
     private int mTouchCurrentY;
 
-    private float mScrollSpeed = 0f;
+    /**
+     * Pivot coordinates for the touch event,
+     * updated when the touch wanders more than {@link #mTouchSlop} in a direction.
+     */
+    private int mTouchPivotX;
+    private int mTouchPivotY;
+
+    /**
+     * Touch direction in each coordinate.
+     */
+    private float mTouchDirectionX;
+    private float mTouchDirectionY;
+
+    private int mTouchSlop;
+
+    private float mScrollSpeed;
     private float mScrollSpeedMax;
 
     /**
@@ -99,47 +119,54 @@ public class DragDropHelper extends RecyclerView.ItemDecoration
      * detaches from the previous one. If {@code null} is provided, it detaches from the current {@link RecyclerView}.
      *
      * {@link DragDropHelper} uses {@link RecyclerView.ItemDecoration}, {@link RecyclerView.OnItemTouchListener} and
-     * {@link RecyclerView.OnChildAttachStateChangeListener} internally, which are set or removed here.
+     * {@link RecyclerView.AdapterDataObserver} internally, the former 2 are set here.
      */
     public void attach(@Nullable RecyclerView recyclerView, @NonNull Callback callback) {
         if (mRecyclerView != recyclerView) {
             if (mRecyclerView != null) {
                 mRecyclerView.removeItemDecoration(this);
                 mRecyclerView.removeOnItemTouchListener(this);
-                mRecyclerView.removeOnChildAttachStateChangeListener(this);
             }
             mRecyclerView = recyclerView;
             if (mRecyclerView != null) {
                 mScrollSpeedMax = TypedValue.applyDimension(
                         TypedValue.COMPLEX_UNIT_DIP, SCROLL_SPEED_MAX_DP,
                         mRecyclerView.getResources().getDisplayMetrics());
+                mTouchSlop = ViewConfiguration.get(recyclerView.getContext()).getScaledTouchSlop();
                 mRecyclerView.addItemDecoration(this, 0);
                 mRecyclerView.addOnItemTouchListener(this);
-                mRecyclerView.addOnChildAttachStateChangeListener(this);
             }
         }
         mCallback = callback;
     }
 
     /**
-     * Starts drag and drop for {@code holder} as soon as there is a touch event, or immediately if one is in progress.
+     * Starts drag and drop for {@code position} as soon as there is a touch event,
+     * or immediately if one is in progress.
      *
      * @return {@code true} if drag is starting, {@code false} if not.
      */
-    public boolean start(@NonNull RecyclerView.ViewHolder holder) {
-        // Ensure current state is valid and that no other drag is currently in progress.
-        if (holder == mViewHolder) {
-            Log.w(LOG_TAG, "View holder is already being dragged");
+    public boolean start(int position) {
+        if (mTracker != null && mTracker.getPosition() == position) {
+            Log.w(LOG_TAG, "Position is already being dragged");
             return false;
         }
-        if (holder.itemView.getParent() != mRecyclerView) {
-            Log.w(LOG_TAG, "View holder which is not a child of this RecyclerView");
+        RecyclerView.ViewHolder holder = mRecyclerView.findViewHolderForAdapterPosition(position);
+        if (holder == null) {
+            Log.w(LOG_TAG, "Can't find view holder for position");
             return false;
         }
-        if (holder.getAdapterPosition() == RecyclerView.NO_POSITION) {
-            Log.w(LOG_TAG, "View holder doesn't have an adapter position");
+        RecyclerView.LayoutManager layoutManager = mRecyclerView.getLayoutManager();
+        if (!(layoutManager instanceof LinearLayoutManager)) {
+            Log.w(LOG_TAG, "RecyclerView is not using LinearLayoutManager");
             return false;
         }
+        RecyclerView.Adapter adapter = mRecyclerView.getAdapter();
+        if (adapter == null) {
+            Log.w(LOG_TAG, "RecyclerView has no adapter");
+            return false;
+        }
+
         if (mState == STATE_STOPPING) {
             Log.w(LOG_TAG, "A drag is currently being stopped");
             return false;
@@ -148,27 +175,21 @@ public class DragDropHelper extends RecyclerView.ItemDecoration
             stop(true);
         }
 
-        // Grab reference to LinearLayoutManager.
-        RecyclerView.LayoutManager layoutManager = mRecyclerView.getLayoutManager();
-        if (!(layoutManager instanceof LinearLayoutManager)) {
-            Log.w(LOG_TAG, "RecyclerView is not using LinearLayoutManager");
-            return false;
-        }
         mLayoutManager = (LinearLayoutManager) layoutManager;
+        mAdapter = adapter;
 
-        // Grab holder and update state.
-        mViewHolder = holder;
-        mState = STATE_STARTING;
+        // Grab position and holder.
+        mTracker = new Tracker(position);
+        mAdapter.registerAdapterDataObserver(mTracker);
+        RecyclerView.ViewHolder viewHolder = mTracker.createViewHolder();
 
         // Get the initial location.
-        mStartLeft = mViewHolder.itemView.getLeft();
-        mStartTop = mViewHolder.itemView.getTop();
-        mLocation.set(mStartLeft, mStartTop, mViewHolder.itemView.getRight(), mViewHolder.itemView.getBottom());
-
-        // Notify callback that the drag has started.
-        mCallback.onDragStarted(mViewHolder, true);
+        mStartLeft = viewHolder.itemView.getLeft();
+        mStartTop = viewHolder.itemView.getTop();
+        mLocation.set(mStartLeft, mStartTop, viewHolder.itemView.getRight(), viewHolder.itemView.getBottom());
 
         // Drag will start.
+        mState = STATE_STARTING;
         return true;
     }
 
@@ -187,12 +208,16 @@ public class DragDropHelper extends RecyclerView.ItemDecoration
     }
 
     private void moveInternal(int x, int y) {
-        int state = mCallback.onDragMoved(mViewHolder, x, y) ? STATE_DRAGGING : STATE_TRACKING;
+        RecyclerView.ViewHolder viewHolder = mTracker.getViewHolder();
+        if (viewHolder == null) {
+            return;
+        }
+        int state = mCallback.onDragMoved(viewHolder, x, y) ? STATE_DRAGGING : STATE_TRACKING;
         if (mState == STATE_DRAGGING && state == STATE_TRACKING) {
-            recoverInternal(mRecyclerView.getItemAnimator());
-            mCallback.onDragStopped(mViewHolder, false);
+            recoverInternal(viewHolder, mRecyclerView.getItemAnimator());
+            mCallback.onDragStopped(viewHolder, false);
         } else if (mState == STATE_TRACKING && state == STATE_DRAGGING) {
-            mCallback.onDragStarted(mViewHolder, false);
+            mCallback.onDragStarted(viewHolder, false);
         }
         mState = state;
     }
@@ -207,8 +232,9 @@ public class DragDropHelper extends RecyclerView.ItemDecoration
     private void stop(boolean now) {
         if (mState != STATE_NONE && mState != STATE_STOPPING) {
             RecyclerView.ItemAnimator itemAnimator = mRecyclerView.getItemAnimator();
-            if (!now && mState == STATE_DRAGGING && itemAnimator != null) {
-                recoverInternal(itemAnimator);
+            RecyclerView.ViewHolder viewHolder = mTracker.getViewHolder();
+            if (!now && mState == STATE_DRAGGING && viewHolder != null && itemAnimator != null) {
+                recoverInternal(viewHolder, itemAnimator);
 
                 // Stop internally after animations are done.
                 itemAnimator.isRunning(new RecyclerView.ItemAnimator.ItemAnimatorFinishedListener() {
@@ -218,7 +244,7 @@ public class DragDropHelper extends RecyclerView.ItemDecoration
                     }
                 });
             } else {
-                if (mState == STATE_RECOVERING && itemAnimator != null) {
+                if (mState == STATE_RECOVERING && viewHolder != null && itemAnimator != null) {
                     itemAnimator.endAnimations();
                 } else {
                     stopInternal();
@@ -240,36 +266,37 @@ public class DragDropHelper extends RecyclerView.ItemDecoration
             return;
         }
 
-        // Remove child order drawing callback.
-        mRecyclerView.setChildDrawingOrderCallback(null);
+        mAdapter.unregisterAdapterDataObserver(mTracker);
+        mAdapter = null;
+        mLayoutManager = null;
 
-        // Reset the scroll speed.
+        mRecyclerView.setChildDrawingOrderCallback(null);
+        mRecyclerView.invalidateItemDecorations();
+
+        mState = STATE_NONE;
         mScrollSpeed = 0;
 
-        // Teardown holder and clear it.
-        setTranslation(0f, 0f);
-        mCallback.onDragStopped(mViewHolder, true);
-        mRecyclerView.invalidateItemDecorations();
-        mState = STATE_NONE;
-        mViewHolder = null;
+        mTracker.destroyViewHolder();
+        mTracker = null;
     }
 
-    private void recoverInternal(@Nullable RecyclerView.ItemAnimator itemAnimator) {
+    private void recoverInternal(
+            @NonNull RecyclerView.ViewHolder viewHolder, @Nullable RecyclerView.ItemAnimator itemAnimator) {
         mState = STATE_RECOVERING;
 
         // Setup preInfo with current translation values.
         RecyclerView.ItemAnimator.ItemHolderInfo preInfo = new RecyclerView.ItemAnimator.ItemHolderInfo();
-        preInfo.left = (int) mViewHolder.itemView.getTranslationX();
-        preInfo.top = (int) mViewHolder.itemView.getTranslationY();
+        preInfo.left = (int) viewHolder.itemView.getTranslationX();
+        preInfo.top = (int) viewHolder.itemView.getTranslationY();
 
         // Setup postInfo with all values at 0 (the default). The intent is to settle in the final position.
         RecyclerView.ItemAnimator.ItemHolderInfo postInfo = new RecyclerView.ItemAnimator.ItemHolderInfo();
 
         // Clear current translation values to prevent them from being added on top of preInfo.
-        setTranslation(0f, 0f);
+        setTranslation(viewHolder, 0f, 0f);
 
         // Animate the move, stopping internally when done.
-        if (itemAnimator != null && itemAnimator.animatePersistence(mViewHolder, preInfo, postInfo)) {
+        if (itemAnimator != null && itemAnimator.animatePersistence(viewHolder, preInfo, postInfo)) {
             itemAnimator.runPendingAnimations();
         }
     }
@@ -291,28 +318,37 @@ public class DragDropHelper extends RecyclerView.ItemDecoration
         }
     }
 
-    private boolean handleMotionEvent(MotionEvent event) {
+    private boolean handleMotionEvent(@NonNull MotionEvent event) {
         if (mState != STATE_NONE && mState != STATE_STOPPING) {
             int action = event.getActionMasked();
             int x = (int) event.getX();
             int y = (int) event.getY();
+
             if (mState == STATE_STARTING && (action == MotionEvent.ACTION_DOWN || action == MotionEvent.ACTION_MOVE)) {
                 // Start the drag.
                 startInternal();
-                mTouchStartX = mTouchCurrentX = x;
-                mTouchStartY = mTouchCurrentY = y;
+                mTouchStartX = mTouchCurrentX = mTouchPivotX = x;
+                mTouchStartY = mTouchCurrentY = mTouchPivotY = y;
                 return true;
             }
             if (mState != STATE_RECOVERING && action == MotionEvent.ACTION_MOVE) {
-                moveInternal(x, y);
                 // Update the drag, the touch event is moving.
+                moveInternal(x, y);
                 mTouchCurrentX = x;
                 mTouchCurrentY = y;
+                if (Math.abs(mTouchCurrentX - mTouchPivotX) > mTouchSlop) {
+                    mTouchDirectionX = Math.signum(mTouchCurrentX - mTouchPivotX);
+                    mTouchPivotX = mTouchCurrentX;
+                }
+                if (Math.abs(mTouchCurrentY - mTouchPivotY) > mTouchSlop) {
+                    mTouchDirectionY = Math.signum(mTouchCurrentY - mTouchPivotY);
+                    mTouchPivotY = mTouchCurrentY;
+                }
                 mRecyclerView.invalidate();
                 return true;
             }
             if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL) {
-                // Stop the drag, the touch event as ended.
+                // Stop the drag, the touch event has ended.
                 stop();
                 return true;
             }
@@ -329,133 +365,117 @@ public class DragDropHelper extends RecyclerView.ItemDecoration
     @Override
     public void onDraw(@NonNull Canvas c, @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
         if (mState != STATE_NONE && mState != STATE_STOPPING) {
+            RecyclerView.ViewHolder viewHolder = mTracker.getViewHolder();
+
             if (mState == STATE_TRACKING || mState == STATE_DRAGGING) {
                 // Update location.
-                updateLocation();
+                updateLocation(viewHolder);
             }
 
-            if (mState == STATE_DRAGGING) {
-                // Offset dragged item.
-                setTranslation(
-                        mLocation.left - mViewHolder.itemView.getLeft(),
-                        mLocation.top - mViewHolder.itemView.getTop());
+            if (viewHolder != null) {
+                if (mState == STATE_DRAGGING) {
+                    // Offset dragged item.
+                    setTranslation(
+                            viewHolder,
+                            mLocation.left - viewHolder.itemView.getLeft(),
+                            mLocation.top - viewHolder.itemView.getTop());
 
-                // Swap with adjacent views if necessary.
-                handleSwap();
+                    // Swap with adjacent views if necessary.
+                    handleSwap(viewHolder);
+                }
+
+                // Handle scrolling when on the edges.
+                handleScroll(viewHolder, mState != STATE_DRAGGING);
             }
-
-            // Handle scrolling when on the edges.
-            handleScroll(mState == STATE_DRAGGING);
         }
     }
 
-    private void setTranslation(float translationX, float translationY) {
-        mViewHolder.itemView.setTranslationX(translationX);
-        mViewHolder.itemView.setTranslationY(translationY);
+    private void setTranslation(@NonNull RecyclerView.ViewHolder viewHolder, float translationX, float translationY) {
+        viewHolder.itemView.setTranslationX(translationX);
+        viewHolder.itemView.setTranslationY(translationY);
     }
 
     /**
-     * Updates the location using the touch position relative to start and the boundaries imposed by
-     * {@link Callback#canSwap(RecyclerView.ViewHolder, RecyclerView.ViewHolder)}.
+     * Updates the location using the touch position relative to start.
      */
-    private void updateLocation() {
-        int position = mViewHolder.getAdapterPosition();
-        if (position != RecyclerView.NO_POSITION) {
-            int width = mViewHolder.itemView.getWidth();
-            int height = mViewHolder.itemView.getHeight();
+    private void updateLocation(@Nullable RecyclerView.ViewHolder viewHolder) {
+        int left = mStartLeft + (mTouchCurrentX - mTouchStartX);
+        int top = mStartTop + (mTouchCurrentY - mTouchStartY);
+
+        if (viewHolder != null) {
+            int width = viewHolder.itemView.getWidth();
+            int height = viewHolder.itemView.getHeight();
             int minLeft = mRecyclerView.getPaddingLeft();
             int maxLeft = mRecyclerView.getWidth() - mRecyclerView.getPaddingRight() - width;
             int minTop = mRecyclerView.getPaddingTop();
             int maxTop = mRecyclerView.getHeight() - mRecyclerView.getPaddingBottom() - height;
 
-            RecyclerView.ViewHolder holderAbove =
-                    mRecyclerView.findViewHolderForAdapterPosition(position - 1);
-            if (holderAbove != null && !mCallback.canSwap(mViewHolder, holderAbove)) {
-                if (mLayoutManager.getOrientation() == LinearLayoutManager.HORIZONTAL) {
-                    minLeft = Math.max(minLeft, holderAbove.itemView.getRight());
-                } else {
-                    minTop = Math.max(minTop, holderAbove.itemView.getBottom());
-                }
-            }
-
-            RecyclerView.ViewHolder holderBelow =
-                    mRecyclerView.findViewHolderForAdapterPosition(position + 1);
-            if (holderBelow != null && !mCallback.canSwap(mViewHolder, holderBelow)) {
-                if (mLayoutManager.getOrientation() == LinearLayoutManager.HORIZONTAL) {
-                    maxLeft = Math.min(maxLeft, holderBelow.itemView.getLeft() - width);
-                } else {
-                    maxTop = Math.min(maxTop, holderBelow.itemView.getTop() - height);
-                }
-            }
-
-            int left = Math.max(minLeft, Math.min(maxLeft, mStartLeft + (mTouchCurrentX - mTouchStartX)));
-            int top = Math.max(minTop, Math.min(maxTop, mStartTop + (mTouchCurrentY - mTouchStartY)));
-            mLocation.offsetTo(left, top);
+            left = MathUtils.clamp(left, minLeft, maxLeft);
+            top = MathUtils.clamp(top, minTop, maxTop);
         }
+
+        mLocation.offsetTo(left, top);
     }
 
     /**
-     * Scrolls the {@link RecyclerView} when close to the edges. Scrolling starts when {@link #mViewHolder} is
-     * width / height away from the edge and accelerates from there.
+     * Scrolls the {@link RecyclerView} when close to the edges and swapping views. Scrolling starts when the
+     * {@link androidx.recyclerview.widget.RecyclerView.ViewHolder} is width / height away from the edge,
+     * and accelerates from there.
      *
      * @param decelerate if {@code true}, the scroll is decelerated regardless of the proximity to the edges.
      */
-    private void handleScroll(boolean decelerate) {
+    private void handleScroll(@NonNull RecyclerView.ViewHolder viewHolder, boolean decelerate) {
         int scrollByX = 0;
         int scrollByY = 0;
         int direction;
 
         if (mLayoutManager.getOrientation() == LinearLayoutManager.HORIZONTAL) {
-            float itemCenterX = (mLocation.left + mLocation.right) / 2f;
-            direction = itemCenterX < mRecyclerView.getWidth() / 2f ? -1 : 1;
-            if (canScrollHorizontally(direction)) {
-                float itemWidth = mLocation.right - mLocation.left;
+            direction = mLocation.centerX() < mRecyclerView.getWidth() / 2f ? -1 : 1;
+            if (!decelerate && canScrollHorizontally(direction)
+                    && Math.abs(viewHolder.itemView.getTranslationX()) < mRecyclerView.getWidth() / 2f) {
                 if (direction == -1) {
                     int left = mRecyclerView.getPaddingLeft();
-                    float boundaryLeft = left + itemWidth;
-                    if (!decelerate && mLocation.left <= boundaryLeft) {
+                    float boundaryLeft = left + mLocation.width();
+                    if (mLocation.left <= boundaryLeft) {
                         updateScrollSpeedAccelerating(1 - ((mLocation.left - left) / (boundaryLeft - left)));
                     } else {
                         updateScrollSpeedDecelerating();
                     }
                 } else {
                     int right = mRecyclerView.getWidth() - mRecyclerView.getPaddingRight();
-                    float boundaryRight = right - itemWidth;
-                    if (!decelerate && mLocation.right >= boundaryRight) {
+                    float boundaryRight = right - mLocation.width();
+                    if (mLocation.right >= boundaryRight) {
                         updateScrollSpeedAccelerating(1 - ((right - mLocation.right) / (right - boundaryRight)));
                     } else {
                         updateScrollSpeedDecelerating();
                     }
                 }
-            } else if (mScrollSpeed > 0) {
-                // Slow down scroll to show the edge glow.
+            } else {
                 updateScrollSpeedDecelerating();
             }
             scrollByX = (int) mScrollSpeed;
         } else {
-            float itemCenterY = (mLocation.top + mLocation.bottom) / 2f;
-            direction = itemCenterY < mRecyclerView.getHeight() / 2f ? -1 : 1;
-            if (canScrollVertically(direction)) {
-                float itemHeight = mLocation.bottom - mLocation.top;
+            direction = mLocation.centerY() < mRecyclerView.getHeight() / 2f ? -1 : 1;
+            if (!decelerate && canScrollVertically(direction)
+                    && Math.abs(viewHolder.itemView.getTranslationY()) < mRecyclerView.getHeight() / 2f) {
                 if (direction == -1) {
                     int top = mRecyclerView.getPaddingTop();
-                    float boundaryTop = top + itemHeight;
-                    if (!decelerate && mLocation.top <= boundaryTop) {
+                    float boundaryTop = top + mLocation.height();
+                    if (mLocation.top <= boundaryTop) {
                         updateScrollSpeedAccelerating(1 - ((mLocation.top - top) / (boundaryTop - top)));
                     } else {
                         updateScrollSpeedDecelerating();
                     }
                 } else {
                     int bottom = mRecyclerView.getHeight() - mRecyclerView.getPaddingBottom();
-                    float boundaryBottom = bottom - itemHeight;
-                    if (!decelerate && mLocation.bottom >= boundaryBottom) {
+                    float boundaryBottom = bottom - mLocation.height();
+                    if (mLocation.bottom >= boundaryBottom) {
                         updateScrollSpeedAccelerating(1 - ((bottom - mLocation.bottom) / (bottom - boundaryBottom)));
                     } else {
                         updateScrollSpeedDecelerating();
                     }
                 }
-            } else if (mScrollSpeed > 0) {
-                // Slow down scroll to show the edge glow.
+            } else {
                 updateScrollSpeedDecelerating();
             }
             scrollByY = (int) mScrollSpeed;
@@ -538,68 +558,84 @@ public class DragDropHelper extends RecyclerView.ItemDecoration
 
     /**
      * Updates the scroll speed for an accelerating motion, up to {@code mScrollSpeedMax}.
-     *
-     * @param fraction How much of the calculated scroll speed should be applied, depending on how close to the
-     *                 boundary it is. [0..1].
      */
     private void updateScrollSpeedAccelerating(float fraction) {
-        mScrollSpeed = Math.min(mScrollSpeedMax * SCROLL_INTERPOLATOR.getInterpolation(fraction), mScrollSpeed * 1.06f);
-        if (mScrollSpeed < 1) {
-            mScrollSpeed = 1;
-        }
+        mScrollSpeed = Math.min(mScrollSpeed * 1.04f, mScrollSpeedMax * fraction);
+        mScrollSpeed = Math.max(mScrollSpeed, 1f);
     }
 
     /**
      * Updates the scroll speed for a decelerating motion, until {@code 0} is reached.
      */
     private void updateScrollSpeedDecelerating() {
-        mScrollSpeed = mScrollSpeedMax > 1 ? mScrollSpeed / 1.2f : 0f;
+        mScrollSpeed = mScrollSpeed > 1f ? mScrollSpeed / 1.18f : 0f;
     }
 
     /**
-     * Swaps {@link #mViewHolder} whenever it overlaps the boundaries of another {@link RecyclerView.ViewHolder}.
+     * Swaps {@code viewHolder} whenever it overlaps the boundaries of another {@link RecyclerView.ViewHolder}.
      */
-    private void handleSwap() {
-        int position = mViewHolder.getAdapterPosition();
-        if (position != RecyclerView.NO_POSITION) {
-            RecyclerView.ViewHolder target = null;
-            if (mLayoutManager.getOrientation() == LinearLayoutManager.HORIZONTAL) {
+    private void handleSwap(@NonNull RecyclerView.ViewHolder viewHolder) {
+        RecyclerView.ViewHolder target = null;
+        int position = mTracker.getPosition();
+        if (mLayoutManager.getOrientation() == LinearLayoutManager.HORIZONTAL) {
+            if (mTouchDirectionX < 0) {
                 RecyclerView.ViewHolder left = mRecyclerView.findViewHolderForAdapterPosition(position - 1);
                 if (left != null && left.itemView.getLeft() >= mLocation.left) {
                     target = left;
-                } else {
-                    RecyclerView.ViewHolder right = mRecyclerView.findViewHolderForAdapterPosition(position + 1);
-                    if (right != null && right.itemView.getRight() <= mLocation.right) {
-                        target = right;
-                    }
                 }
-            } else {
+            } else if (mTouchDirectionX > 0) {
+                RecyclerView.ViewHolder right = mRecyclerView.findViewHolderForAdapterPosition(position + 1);
+                if (right != null && right.itemView.getRight() <= mLocation.right) {
+                    target = right;
+                }
+            }
+        } else {
+            if (mTouchDirectionY < 0) {
                 RecyclerView.ViewHolder top = mRecyclerView.findViewHolderForAdapterPosition(position - 1);
                 if (top != null && top.itemView.getTop() >= mLocation.top) {
                     target = top;
-                } else {
-                    RecyclerView.ViewHolder bottom = mRecyclerView.findViewHolderForAdapterPosition(position + 1);
-                    if (bottom != null && bottom.itemView.getBottom() <= mLocation.bottom) {
-                        target = bottom;
-                    }
+                }
+            } else if (mTouchDirectionY > 0) {
+                RecyclerView.ViewHolder bottom = mRecyclerView.findViewHolderForAdapterPosition(position + 1);
+                if (bottom != null && bottom.itemView.getBottom() <= mLocation.bottom) {
+                    target = bottom;
                 }
             }
-
-            int targetPosition;
-            if (target != null && (targetPosition = target.getAdapterPosition()) != RecyclerView.NO_POSITION) {
-                // Prevent unintended scrolling when swapping the very first and last views, as they are used as anchor
-                // views hence hinting RV to scroll while animating.
-                if (position == 0 || targetPosition == 0) {
-                    mLayoutManager.scrollToPosition(0);
-                } else {
+        }
+        int targetPosition;
+        if (target != null && (targetPosition = target.getAdapterPosition()) != RecyclerView.NO_POSITION) {
+            int newPosition = mCallback.onDragTo(viewHolder, targetPosition);
+            if (newPosition != position) {
+                // Prevent unintended scrolling when swapping the very first and last views,
+                // when they act as anchor views. Not doing so triggers unintended scrolling.
+                if (mLayoutManager.getReverseLayout()) {
                     int lastPosition = getItemCount() - 1;
-                    if (position == lastPosition || targetPosition == lastPosition) {
+                    if (position == lastPosition || newPosition == lastPosition) {
                         mLayoutManager.scrollToPosition(lastPosition);
                     }
+                } else if (position == 0 || newPosition == 0) {
+                    mLayoutManager.scrollToPosition(0);
                 }
-
-                mCallback.onSwap(mViewHolder, target);
             }
+        }
+    }
+
+    @Override
+    public int onGetChildDrawingOrder(int childCount, int i) {
+        RecyclerView.ViewHolder viewHolder = mTracker.getViewHolder();
+        if (viewHolder == null) {
+            return i;
+        }
+        int itemPosition = mRecyclerView.indexOfChild(viewHolder.itemView);
+        if (itemPosition == -1) {
+            // RV will on rare occasions return a VH that has an adapter position, but its item view is not present
+            // in the hierarchy. This is an intermediate state which we can safely ignore.
+            return i;
+        }
+        if (i == childCount - 1) {
+            return itemPosition;
+        } else {
+            return i < itemPosition ? i : i + 1;
         }
     }
 
@@ -612,67 +648,141 @@ public class DragDropHelper extends RecyclerView.ItemDecoration
         }
     }
 
-    @Override
-    public int onGetChildDrawingOrder(int childCount, int i) {
-        int itemPosition = mRecyclerView.indexOfChild(mViewHolder.itemView);
-        if (i == childCount - 1) {
-            return itemPosition;
-        } else {
-            return i < itemPosition ? i : i + 1;
-        }
-    }
+    /**
+     * Keeps track of the drag & drop position and holder across swaps, scrolls and adapter changes.
+     */
+    private class Tracker extends RecyclerView.AdapterDataObserver {
+        private int position;
+        private RecyclerView.ViewHolder viewHolder;
 
-    @Override
-    public void onChildViewAttachedToWindow(@NonNull View view) {
-    }
-
-    @Override
-    public void onChildViewDetachedFromWindow(@NonNull View view) {
-        RecyclerView.ViewHolder holder = mRecyclerView.getChildViewHolder(view);
-        if (holder == null) {
-            return;
+        Tracker(int position) {
+            this.position = position;
         }
-        if (holder == mViewHolder) {
+
+        /**
+         * @return the position being dragged, updated automatically through adapter changes.
+         */
+        int getPosition() {
+            return position;
+        }
+
+        /**
+         * @return the view holder being dragged, updated automatically through adapter changes, swaps, scrolls, etc.
+         */
+        RecyclerView.ViewHolder getViewHolder() {
+            if (viewHolder != null && viewHolder.itemView.getParent() != mRecyclerView) {
+                teardownViewHolder(false);
+            }
+            if (viewHolder == null) {
+                setupViewHolder(false);
+            }
+            if (viewHolder == null && !mRecyclerView.isLayoutRequested()) {
+                mRecyclerView.scrollToPosition(position);
+            }
+            return viewHolder;
+        }
+
+        RecyclerView.ViewHolder createViewHolder() {
+            return setupViewHolder(true);
+        }
+
+        void destroyViewHolder() {
+            teardownViewHolder(true);
+        }
+
+        private RecyclerView.ViewHolder setupViewHolder(boolean create) {
+            viewHolder = mRecyclerView.findViewHolderForAdapterPosition(position);
+            if (viewHolder != null) {
+                mCallback.onDragStarted(viewHolder, create);
+            }
+            return viewHolder;
+        }
+
+        private void teardownViewHolder(boolean destroy) {
+            setTranslation(viewHolder, 0f, 0f);
+            mCallback.onDragStopped(viewHolder, destroy);
+            viewHolder = null;
+        }
+
+        @Override
+        public void onChanged() {
             stop(true);
+        }
+
+        @Override
+        public void onItemRangeInserted(int positionStart, int itemCount) {
+            if (positionStart < position) {
+                position += itemCount;
+            }
+        }
+
+        @Override
+        public void onItemRangeRemoved(int positionStart, int itemCount) {
+            if (position >= positionStart && position < positionStart + itemCount) {
+                stop(true);
+            } else if (positionStart < position) {
+                position -= itemCount;
+            }
+        }
+
+        @Override
+        public void onItemRangeMoved(int fromPosition, int toPosition, int itemCount) {
+            if (position >= fromPosition && position < fromPosition + itemCount) {
+                position += toPosition - fromPosition;
+            } else if (fromPosition < toPosition && position >= fromPosition + itemCount && position <= toPosition) {
+                position -= itemCount;
+            } else if (fromPosition > toPosition && position >= toPosition && position <= fromPosition) {
+                position += itemCount;
+            }
         }
     }
 
     public interface Callback {
         /**
-         * A drag has started for {@code holder}. It can be the very start of the drag, or a resume as
-         * signalled by the result of {@link #onDragMoved(RecyclerView.ViewHolder, int, int)}.
+         * A drag has started or its {@link RecyclerView.ViewHolder} has changed. {@code holder} can be setup in this
+         * callback (e.g. elevate, change background, etc).
          *
-         * @param create true when the drag has just started, false when its being resumed (eg. re-entered bounds).
+         * This can be called multiple times during a single drag. {@code create} will be true when the drag is
+         * starting, and false for all subsequent calls following {@link RecyclerView.ViewHolder} changes.
+         *
+         * @param create true when the drag has just started, false when its being resumed
+         *               (e.g. after scroll or re-entering bounds).
          */
         void onDragStarted(@NonNull RecyclerView.ViewHolder holder, boolean create);
 
         /**
-         * A drag has moved. The callback determines whether the drag should continue on screen (return true), simply
-         * be tracked to be resumed later (return false), or stopped (call {@link #stop()}).
+         * A drag has moved. The callback determines whether the drag should visually continue on screen
+         * (return {@code true}), simply be tracked (return {@code false}), or stopped (call {@link #stop()}).
+         *
+         * Most implementations should simply return {@code true}. This becomes useful when implementations want to
+         * trigger certain behaviors or workflows based off of dragging coordinates. Examples include indenting while
+         * reordering, handing off control to Android's native drag & drop when dragging out of bounds, etc.
          *
          * @param x x-coordinate of the drag, in the parent's coordinates.
          * @param y y-coordinate of the drag, in the parent's coordinates.
-         * @return true to have the {@code holder} track the drag on screen.
+         * @return {@code true} for the {@code holder} to drag on screen, {@code false} to track without visual changes.
          */
         boolean onDragMoved(@NonNull RecyclerView.ViewHolder holder, int x, int y);
 
         /**
-         * Called to determine whether {@code holder} can be swapped with {@code target}.
-         * {@link #onSwap(RecyclerView.ViewHolder, RecyclerView.ViewHolder)} might be called later on
-         * if true.
-         */
-        boolean canSwap(@NonNull RecyclerView.ViewHolder holder, @NonNull RecyclerView.ViewHolder target);
-
-        /**
-         * Swap {@code holder} to {@code target}'s adapter position and notify the {@link RecyclerView.Adapter}.
-         */
-        void onSwap(@NonNull RecyclerView.ViewHolder holder, @NonNull RecyclerView.ViewHolder target);
-
-        /**
-         * A drag has stopped for {@code holder}. It can be the final ending of the drag, or a pause as
-         * signalled by the result of {@link #onDragMoved(RecyclerView.ViewHolder, int, int)}.
+         * Move {@code holder} to {@code adapterPosition} and notify the {@link RecyclerView.Adapter}.
          *
-         * @param destroy true when the drag is ending, false when it's pausing (eg. exited bounds).
+         * Implementations can move {@code holder} to any position. {@code target} is a mere indication of where
+         * the user is trying to move to, which implementations should typically honor, but not mandatorily.
+         *
+         * @return the adapter position that {@code holder} moved to.
+         */
+        int onDragTo(@NonNull RecyclerView.ViewHolder holder, int to);
+
+        /**
+         * A drag has stopped or its {@link RecyclerView.ViewHolder} will change. Any setup done to {@code holder} in
+         * {@link #onDragStarted(RecyclerView.ViewHolder, boolean)} should be undone here.
+         *
+         * This can be called multiple times during a single drag. {@code destroy} will be true when the drag is
+         * ending, and false for any prior calls following {@link RecyclerView.ViewHolder} changes.
+         *
+         * @param destroy true when the drag is ending, false when it's pausing
+         *                (e.g. scrolling or exiting bounds).
          */
         void onDragStopped(@NonNull RecyclerView.ViewHolder holder, boolean destroy);
     }

--- a/DragDrop/src/main/java/io/doist/recyclerviewext/dragdrop/DragDropHelper.java
+++ b/DragDrop/src/main/java/io/doist/recyclerviewext/dragdrop/DragDropHelper.java
@@ -12,7 +12,6 @@ import android.view.animation.Interpolator;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.view.MotionEventCompat;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -57,7 +56,7 @@ public class DragDropHelper extends RecyclerView.ItemDecoration
     /**
      * Dragged item's location on screen.
      */
-    private Rect mLocation = new Rect();
+    private final Rect mLocation = new Rect();
     private int mStartLeft;
     private int mStartTop;
 
@@ -202,7 +201,6 @@ public class DragDropHelper extends RecyclerView.ItemDecoration
         }
     }
 
-    @SuppressWarnings("unchecked")
     private void stopInternal() {
         // Postpone stopping if a layout is being computed.
         mState = STATE_STOPPING;
@@ -231,12 +229,12 @@ public class DragDropHelper extends RecyclerView.ItemDecoration
     }
 
     @Override
-    public boolean onInterceptTouchEvent(RecyclerView rv, MotionEvent e) {
+    public boolean onInterceptTouchEvent(@NonNull RecyclerView rv, @NonNull MotionEvent e) {
         return handleMotionEvent(e);
     }
 
     @Override
-    public void onTouchEvent(RecyclerView rv, MotionEvent e) {
+    public void onTouchEvent(@NonNull RecyclerView rv, @NonNull MotionEvent e) {
         handleMotionEvent(e);
     }
 
@@ -249,7 +247,7 @@ public class DragDropHelper extends RecyclerView.ItemDecoration
 
     private boolean handleMotionEvent(MotionEvent event) {
         if (mState != STATE_NONE && mState != STATE_STOPPING) {
-            int action = MotionEventCompat.getActionMasked(event);
+            int action = event.getActionMasked();
             int x = (int) event.getX();
             int y = (int) event.getY();
             if (mState == STATE_STARTING && (action == MotionEvent.ACTION_DOWN || action == MotionEvent.ACTION_MOVE)) {
@@ -276,14 +274,13 @@ public class DragDropHelper extends RecyclerView.ItemDecoration
     }
 
     @Override
-    public void getItemOffsets(Rect outRect, View view, RecyclerView parent, RecyclerView.State state) {
+    public void getItemOffsets(
+            Rect outRect, @NonNull View view, @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
         outRect.setEmpty();
     }
 
     @Override
-    public void onDraw(Canvas c, RecyclerView parent, RecyclerView.State state) {
-        super.onDraw(c, parent, state);
-
+    public void onDraw(@NonNull Canvas c, @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
         if (mState != STATE_NONE && mState != STATE_STOPPING) {
             boolean dragging = mState == STATE_DRAGGING;
 
@@ -441,7 +438,7 @@ public class DragDropHelper extends RecyclerView.ItemDecoration
                     return true;
                 }
             } else {
-                holder = mRecyclerView.findViewHolderForAdapterPosition(mRecyclerView.getAdapter().getItemCount() - 1);
+                holder = mRecyclerView.findViewHolderForAdapterPosition(getItemCount() - 1);
                 if (holder != null) {
                     int maxBottom = Integer.MIN_VALUE;
                     for (int i = 0; i < childCount; i++) {
@@ -476,7 +473,7 @@ public class DragDropHelper extends RecyclerView.ItemDecoration
                     return true;
                 }
             } else {
-                holder = mRecyclerView.findViewHolderForAdapterPosition(mRecyclerView.getAdapter().getItemCount() - 1);
+                holder = mRecyclerView.findViewHolderForAdapterPosition(getItemCount() - 1);
                 if (holder != null) {
                     int maxRight = Integer.MIN_VALUE;
                     for (int i = 0; i < childCount; i++) {
@@ -547,7 +544,7 @@ public class DragDropHelper extends RecyclerView.ItemDecoration
                 if (position == 0 || targetPosition == 0) {
                     mLayoutManager.scrollToPosition(0);
                 } else {
-                    int lastPosition = mRecyclerView.getAdapter().getItemCount() - 1;
+                    int lastPosition = getItemCount() - 1;
                     if (position == lastPosition || targetPosition == lastPosition) {
                         mLayoutManager.scrollToPosition(lastPosition);
                     }
@@ -555,6 +552,15 @@ public class DragDropHelper extends RecyclerView.ItemDecoration
 
                 mCallback.onSwap(mViewHolder, target);
             }
+        }
+    }
+
+    private int getItemCount() {
+        RecyclerView.Adapter adapter = mRecyclerView.getAdapter();
+        if (adapter != null) {
+            return adapter.getItemCount();
+        } else {
+            return 0;
         }
     }
 
@@ -569,11 +575,11 @@ public class DragDropHelper extends RecyclerView.ItemDecoration
     }
 
     @Override
-    public void onChildViewAttachedToWindow(View view) {
+    public void onChildViewAttachedToWindow(@NonNull View view) {
     }
 
     @Override
-    public void onChildViewDetachedFromWindow(View view) {
+    public void onChildViewDetachedFromWindow(@NonNull View view) {
         RecyclerView.ViewHolder holder = mRecyclerView.getChildViewHolder(view);
         if (holder == null) {
             return;

--- a/Flippers/build.gradle
+++ b/Flippers/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    buildToolsVersion "29.0.2"
 
     defaultConfig {
         minSdkVersion 16
@@ -13,5 +13,5 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.recyclerview:recyclerview:1.0.0'
+    implementation "androidx.recyclerview:recyclerview:1.0.0"
 }

--- a/Flippers/src/main/java/io/doist/recyclerviewext/flippers/EmptyRecyclerFlipper.java
+++ b/Flippers/src/main/java/io/doist/recyclerviewext/flippers/EmptyRecyclerFlipper.java
@@ -13,8 +13,8 @@ import androidx.recyclerview.widget.RecyclerView;
  * {@link ListView}.
  */
 public class EmptyRecyclerFlipper extends Flipper {
-    protected RecyclerView mRecyclerView;
-    protected View mEmptyView;
+    private final RecyclerView mRecyclerView;
+    private final View mEmptyView;
 
     private RecyclerView.Adapter mAdapter;
     private int mCount;

--- a/Flippers/src/main/java/io/doist/recyclerviewext/flippers/FlipperAnimator.java
+++ b/Flippers/src/main/java/io/doist/recyclerviewext/flippers/FlipperAnimator.java
@@ -6,7 +6,7 @@ import android.view.View;
  * Animates transitions between views with the same parent.
  */
 public abstract class FlipperAnimator {
-    public static long DEFAULT_DURATION = 250;
+    public static final long DEFAULT_DURATION = 250;
 
     private long mDuration = DEFAULT_DURATION;
 

--- a/Flippers/src/main/java/io/doist/recyclerviewext/flippers/ProgressEmptyRecyclerFlipper.java
+++ b/Flippers/src/main/java/io/doist/recyclerviewext/flippers/ProgressEmptyRecyclerFlipper.java
@@ -10,7 +10,7 @@ import androidx.recyclerview.widget.RecyclerView;
  * Similar to {@link EmptyRecyclerFlipper}, but also handles a progress view through {@link #setLoading(boolean)}.
  */
 public class ProgressEmptyRecyclerFlipper extends EmptyRecyclerFlipper {
-    private View mProgressView;
+    private final View mProgressView;
     private View mCurrentView;
     private boolean mLoading;
 

--- a/PinchZoom/build.gradle
+++ b/PinchZoom/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    buildToolsVersion "29.0.2"
 
     defaultConfig {
         minSdkVersion 16
@@ -13,5 +13,5 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.recyclerview:recyclerview:1.0.0'
+    implementation "androidx.recyclerview:recyclerview:1.0.0"
 }

--- a/PinchZoom/src/main/java/io/doist/recyclerviewext/pinch_zoom/PinchZoomItemTouchListener.java
+++ b/PinchZoom/src/main/java/io/doist/recyclerviewext/pinch_zoom/PinchZoomItemTouchListener.java
@@ -15,7 +15,7 @@ import android.view.ViewParent;
 import android.view.animation.DecelerateInterpolator;
 import android.view.animation.Interpolator;
 
-import androidx.core.view.MotionEventCompat;
+import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -30,9 +30,9 @@ public class PinchZoomItemTouchListener
     private static final int SETTLE_DURATION_MS = 250;
     private static final Interpolator SETTLE_INTERPOLATOR = new DecelerateInterpolator();
 
-    private ScaleGestureDetector mScaleGestureDetector;
-    private int mSpanSlop;
-    private PinchZoomListener mListener;
+    private final ScaleGestureDetector mScaleGestureDetector;
+    private final int mSpanSlop;
+    private final PinchZoomListener mListener;
 
     private boolean mEnabled = true;
 
@@ -60,14 +60,15 @@ public class PinchZoomItemTouchListener
     }
 
     @Override
-    public boolean onInterceptTouchEvent(RecyclerView rv, MotionEvent e) {
+    public boolean onInterceptTouchEvent(
+            @NonNull RecyclerView recyclerView, @NonNull MotionEvent event) {
         if (!mEnabled) {
             return false;
         }
 
         // Bail out when onRequestDisallowInterceptTouchEvent is called and the motion event has started.
         if (mDisallowInterceptTouchEvent) {
-            switch (MotionEventCompat.getActionMasked(e)) {
+            switch (event.getActionMasked()) {
                 case MotionEvent.ACTION_DOWN:
                     mDisallowInterceptTouchEvent = false;
                     break; // Continue handling since down event should always be handled.
@@ -80,21 +81,21 @@ public class PinchZoomItemTouchListener
         }
 
         // Grab RV reference and current orientation.
-        mRecyclerView = rv;
-        if (rv.getLayoutManager() instanceof LinearLayoutManager) {
-            mOrientation = ((LinearLayoutManager) rv.getLayoutManager()).getOrientation();
+        mRecyclerView = recyclerView;
+        if (recyclerView.getLayoutManager() instanceof LinearLayoutManager) {
+            mOrientation = ((LinearLayoutManager) recyclerView.getLayoutManager()).getOrientation();
         } else {
             throw new IllegalStateException("PinchZoomItemTouchListener only supports LinearLayoutManager");
         }
 
-        // Proxy the call to ScaleGestureDetector. Its onScaleBegin() method sets mIntercept when called.
-        mScaleGestureDetector.onTouchEvent(e);
+        // Proxy to ScaleGestureDetector. Its onScaleBegin() method sets mIntercept when called.
+        mScaleGestureDetector.onTouchEvent(event);
         return mIntercept;
     }
 
     @Override
-    public void onTouchEvent(RecyclerView rv, MotionEvent e) {
-        mScaleGestureDetector.onTouchEvent(e);
+    public void onTouchEvent(@NonNull RecyclerView recyclerView, @NonNull MotionEvent event) {
+        mScaleGestureDetector.onTouchEvent(event);
     }
 
     @Override

--- a/Samples/build.gradle
+++ b/Samples/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    buildToolsVersion "29.0.2"
 
     defaultConfig {
         applicationId "io.doist.recyclerviewext"
@@ -11,6 +11,7 @@ android {
         versionCode 1
         versionName "1.0"
     }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -19,8 +20,8 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'androidx.recyclerview:recyclerview:1.0.0'
+    implementation "androidx.appcompat:appcompat:1.0.2"
+    implementation "androidx.recyclerview:recyclerview:1.0.0"
 
     implementation project(':Animations')
     implementation project(':ClickListeners')

--- a/Samples/src/main/java/io/doist/recyclerviewext/demo/DemoAdapter.java
+++ b/Samples/src/main/java/io/doist/recyclerviewext/demo/DemoAdapter.java
@@ -13,6 +13,7 @@ import android.widget.TextView;
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 import io.doist.recyclerviewext.R;
 import io.doist.recyclerviewext.animations.AnimatedAdapter;
@@ -22,7 +23,8 @@ import io.doist.recyclerviewext.sticky_headers.StickyHeaders;
 
 public class DemoAdapter extends AnimatedAdapter<BindableViewHolder>
         implements StickyHeaders, DragDropHelper.Callback {
-    private boolean mHorizontal;
+    @RecyclerView.Orientation
+    private final int mOrientation;
 
     private Selector mSelector;
 
@@ -30,9 +32,9 @@ public class DemoAdapter extends AnimatedAdapter<BindableViewHolder>
 
     private List<Object> mDataset;
 
-    DemoAdapter(boolean horizontal) {
+    DemoAdapter(int orientation) {
         super();
-        mHorizontal = horizontal;
+        mOrientation = orientation;
     }
 
     void setDataset(List<Object> dataset) {
@@ -48,20 +50,23 @@ public class DemoAdapter extends AnimatedAdapter<BindableViewHolder>
         mDragDropHelper = dragDropHelper;
     }
 
+    @NonNull
     @Override
     public BindableViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         LayoutInflater inflater = LayoutInflater.from(parent.getContext());
         if (viewType == 0) {
-            return new DemoItemViewHolder(
-                    inflater.inflate(mHorizontal ? R.layout.item_horizontal : R.layout.item, parent, false));
+            return new DemoItemViewHolder(inflater.inflate(
+                    mOrientation == RecyclerView.VERTICAL ?
+                    R.layout.item : R.layout.item_horizontal, parent, false));
         } else {
-            return new DemoSectionViewHolder(
-                    inflater.inflate(mHorizontal ? R.layout.section_horizontal : R.layout.section, parent, false));
+            return new DemoSectionViewHolder(inflater.inflate(
+                    mOrientation == RecyclerView.VERTICAL ?
+                    R.layout.section : R.layout.section_horizontal, parent, false));
         }
     }
 
     @Override
-    public void onBindViewHolder(BindableViewHolder holder, int position) {
+    public void onBindViewHolder(@NonNull BindableViewHolder holder, int position) {
         if (mSelector != null) {
             mSelector.bind(holder, true);
         }
@@ -128,15 +133,18 @@ public class DemoAdapter extends AnimatedAdapter<BindableViewHolder>
                 @Override
                 public void onAnimationEnd(Animator animation) {
                     holder.itemView.setTranslationZ(0f);
+                    holder.itemView.setBackground(null);
                 }
             });
+        } else {
+            holder.itemView.setBackground(null);
         }
     }
 
     public class DemoItemViewHolder extends BindableViewHolder implements View.OnClickListener,
                                                                           View.OnLongClickListener {
-        TextView textView1;
-        TextView textView2;
+        final TextView textView1;
+        final TextView textView2;
 
         DemoItemViewHolder(View itemView) {
             super(itemView);
@@ -168,7 +176,7 @@ public class DemoAdapter extends AnimatedAdapter<BindableViewHolder>
     }
 
     public class DemoSectionViewHolder extends BindableViewHolder implements View.OnClickListener {
-        TextView textView;
+        final TextView textView;
 
         DemoSectionViewHolder(View itemView) {
             super(itemView);

--- a/Samples/src/main/java/io/doist/recyclerviewext/demo/DemoAdapter.java
+++ b/Samples/src/main/java/io/doist/recyclerviewext/demo/DemoAdapter.java
@@ -100,16 +100,19 @@ public class DemoAdapter extends AnimatedAdapter<BindableViewHolder>
     }
 
     @Override
-    public void onDragStarted(final RecyclerView.ViewHolder holder, boolean create) {
-        holder.itemView.setBackgroundColor(Color.WHITE);
+    public void onDragStarted(@NonNull final RecyclerView.ViewHolder holder, boolean create) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            holder.itemView.animate().translationZ(8f).setDuration(200L).setListener(new AnimatorListenerAdapter() {
-                @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-                @Override
-                public void onAnimationEnd(Animator animation) {
-                    holder.itemView.setTranslationZ(8f);
-                }
-            });
+            if (create) {
+                holder.itemView.animate().translationZ(8f).setDuration(200L).setListener(new AnimatorListenerAdapter() {
+                    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+                    @Override
+                    public void onAnimationEnd(Animator animation) {
+                        holder.itemView.setTranslationZ(8f);
+                    }
+                });
+            } else {
+                holder.itemView.setTranslationZ(8f);
+            }
         }
     }
 
@@ -121,36 +124,32 @@ public class DemoAdapter extends AnimatedAdapter<BindableViewHolder>
     }
 
     @Override
-    public boolean canSwap(@NonNull RecyclerView.ViewHolder holder, @NonNull RecyclerView.ViewHolder target) {
-        return true; //holder.getClass() == target.getClass();
-    }
-
-    @Override
-    public void onSwap(RecyclerView.ViewHolder holder, RecyclerView.ViewHolder target) {
+    public int onDragTo(@NonNull RecyclerView.ViewHolder holder, int to) {
         int from = holder.getAdapterPosition();
-        int to = target.getAdapterPosition();
         mDataset.add(to, mDataset.remove(from));
         notifyItemMoved(from, to);
+        return to;
     }
 
     @Override
     public void onDragStopped(@NonNull final RecyclerView.ViewHolder holder, boolean destroy) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            holder.itemView.animate().translationZ(0f).setDuration(200L).setListener(new AnimatorListenerAdapter() {
-                @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-                @Override
-                public void onAnimationEnd(Animator animation) {
-                    holder.itemView.setTranslationZ(0f);
-                    holder.itemView.setBackground(null);
-                }
-            });
-        } else {
-            holder.itemView.setBackground(null);
+            if (destroy) {
+                holder.itemView.animate().translationZ(0f).setDuration(200L).setListener(new AnimatorListenerAdapter() {
+                    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+                    @Override
+                    public void onAnimationEnd(Animator animation) {
+                        holder.itemView.setTranslationZ(0f);
+                    }
+                });
+            } else {
+                holder.itemView.setTranslationZ(0f);
+            }
         }
     }
 
-    public class DemoItemViewHolder extends BindableViewHolder implements View.OnClickListener,
-                                                                          View.OnLongClickListener {
+    public class DemoItemViewHolder extends BindableViewHolder
+            implements View.OnClickListener, View.OnLongClickListener {
         final TextView textView1;
         final TextView textView2;
 
@@ -178,7 +177,7 @@ public class DemoAdapter extends AnimatedAdapter<BindableViewHolder>
 
         @Override
         public boolean onLongClick(View v) {
-            mDragDropHelper.start(DemoItemViewHolder.this);
+            mDragDropHelper.start(getAdapterPosition());
             return true;
         }
     }

--- a/Samples/src/main/java/io/doist/recyclerviewext/demo/DemoAdapter.java
+++ b/Samples/src/main/java/io/doist/recyclerviewext/demo/DemoAdapter.java
@@ -4,6 +4,7 @@ import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.annotation.TargetApi;
 import android.graphics.Color;
+import android.graphics.Rect;
 import android.os.Build;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -99,7 +100,7 @@ public class DemoAdapter extends AnimatedAdapter<BindableViewHolder>
     }
 
     @Override
-    public void onDragStarted(final RecyclerView.ViewHolder holder) {
+    public void onDragStarted(final RecyclerView.ViewHolder holder, boolean create) {
         holder.itemView.setBackgroundColor(Color.WHITE);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             holder.itemView.animate().translationZ(8f).setDuration(200L).setListener(new AnimatorListenerAdapter() {
@@ -113,7 +114,14 @@ public class DemoAdapter extends AnimatedAdapter<BindableViewHolder>
     }
 
     @Override
-    public boolean canSwap(RecyclerView.ViewHolder holder, RecyclerView.ViewHolder target) {
+    public boolean onDragMoved(@NonNull RecyclerView.ViewHolder holder, int x, int y) {
+        Rect rect = new Rect();
+        ((View) holder.itemView.getParent()).getDrawingRect(rect);
+        return rect.contains(x, y);
+    }
+
+    @Override
+    public boolean canSwap(@NonNull RecyclerView.ViewHolder holder, @NonNull RecyclerView.ViewHolder target) {
         return true; //holder.getClass() == target.getClass();
     }
 
@@ -126,7 +134,7 @@ public class DemoAdapter extends AnimatedAdapter<BindableViewHolder>
     }
 
     @Override
-    public void onDragStopped(final RecyclerView.ViewHolder holder) {
+    public void onDragStopped(@NonNull final RecyclerView.ViewHolder holder, boolean destroy) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             holder.itemView.animate().translationZ(0f).setDuration(200L).setListener(new AnimatorListenerAdapter() {
                 @TargetApi(Build.VERSION_CODES.LOLLIPOP)

--- a/Samples/src/main/res/drawable/item_background.xml
+++ b/Samples/src/main/res/drawable/item_background.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_activated="true" android:drawable="@color/item_activated" />
-    <item android:drawable="@android:color/transparent" />
+    <item android:drawable="@color/item" />
 </selector>

--- a/Samples/src/main/res/layout/activity_demo.xml
+++ b/Samples/src/main/res/layout/activity_demo.xml
@@ -3,7 +3,6 @@
     android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#fff"
     android:padding="8dip">
 
     <androidx.recyclerview.widget.RecyclerView

--- a/Samples/src/main/res/layout/activity_demo.xml
+++ b/Samples/src/main/res/layout/activity_demo.xml
@@ -19,7 +19,8 @@
         android:paddingBottom="24dip"
         android:paddingLeft="16dip"
         android:paddingRight="16dip"
-        android:paddingTop="24dip" />
+        android:paddingTop="24dip"
+        android:scrollbars="horizontal|vertical"/>
 
     <TextView
         android:id="@+id/empty"

--- a/Samples/src/main/res/layout/activity_demo.xml
+++ b/Samples/src/main/res/layout/activity_demo.xml
@@ -1,9 +1,11 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="8dip">
+    android:paddingLeft="@dimen/horizontal_padding"
+    android:paddingStart="@dimen/horizontal_padding"
+    android:paddingRight="@dimen/horizontal_padding"
+    android:paddingEnd="@dimen/horizontal_padding">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_view"

--- a/Samples/src/main/res/values-xlarge/dimens.xml
+++ b/Samples/src/main/res/values-xlarge/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="horizontal_padding">160dip</dimen>
+</resources>

--- a/Samples/src/main/res/values/colors.xml
+++ b/Samples/src/main/res/values/colors.xml
@@ -3,5 +3,6 @@
     <color name="section">#eee</color>
     <color name="section_pressed">#ccc</color>
 
+    <color name="item">#fff</color>
     <color name="item_activated">#eee</color>
 </resources>

--- a/Samples/src/main/res/values/dimens.xml
+++ b/Samples/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="horizontal_padding">0dip</dimen>
+</resources>

--- a/Selectors/build.gradle
+++ b/Selectors/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    buildToolsVersion "29.0.2"
 
     defaultConfig {
         minSdkVersion 16
@@ -13,5 +13,5 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.recyclerview:recyclerview:1.0.0'
+    implementation "androidx.recyclerview:recyclerview:1.0.0"
 }

--- a/Selectors/src/main/java/io/doist/recyclerviewext/choice_modes/MultiSelector.java
+++ b/Selectors/src/main/java/io/doist/recyclerviewext/choice_modes/MultiSelector.java
@@ -18,7 +18,7 @@ import androidx.recyclerview.widget.RecyclerView;
  * {@link android.R.attr#state_activated} reflect the selected state.
  */
 public class MultiSelector extends Selector {
-    protected Set<Long> mSelectedIds = new LinkedHashSet<>();
+    private final Set<Long> mSelectedIds = new LinkedHashSet<>();
 
     public MultiSelector(@NonNull RecyclerView recyclerView, @NonNull RecyclerView.Adapter adapter) {
         super(recyclerView, adapter);

--- a/Selectors/src/main/java/io/doist/recyclerviewext/choice_modes/Selector.java
+++ b/Selectors/src/main/java/io/doist/recyclerviewext/choice_modes/Selector.java
@@ -21,8 +21,8 @@ public abstract class Selector {
 
     private static final String KEY_SELECTOR_SELECTED_IDS = ":selector_selected_ids";
 
-    protected RecyclerView mRecyclerView;
-    protected RecyclerView.Adapter mAdapter;
+    protected final RecyclerView mRecyclerView;
+    protected final RecyclerView.Adapter mAdapter;
 
     protected OnSelectionChangedListener mObserver;
 
@@ -127,7 +127,7 @@ public abstract class Selector {
     }
 
     private class SelectorAdapterDataObserver extends RecyclerView.AdapterDataObserver {
-        private DeselectMissingIdsRunnable mDeselectMissingIdsRunnable = new DeselectMissingIdsRunnable();
+        private final DeselectMissingIdsRunnable mDeselectMissingIdsRunnable = new DeselectMissingIdsRunnable();
 
         @Override
         public void onChanged() {

--- a/StickyHeaders/build.gradle
+++ b/StickyHeaders/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    buildToolsVersion "29.0.2"
 
     defaultConfig {
         minSdkVersion 16
@@ -13,5 +13,5 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.recyclerview:recyclerview:1.0.0'
+    implementation "androidx.recyclerview:recyclerview:1.0.0"
 }

--- a/StickyHeaders/src/main/java/io/doist/recyclerviewext/sticky_headers/StickyHeadersLinearLayoutManager.java
+++ b/StickyHeaders/src/main/java/io/doist/recyclerviewext/sticky_headers/StickyHeadersLinearLayoutManager.java
@@ -261,8 +261,40 @@ public class StickyHeadersLinearLayoutManager<T extends RecyclerView.Adapter & S
     }
 
     @Override
-    public View onFocusSearchFailed(View focused, int focusDirection, RecyclerView.Recycler recycler,
-                                    RecyclerView.State state) {
+    public int findFirstVisibleItemPosition() {
+        detachStickyHeader();
+        int position = super.findFirstVisibleItemPosition();
+        attachStickyHeader();
+        return position;
+    }
+
+    @Override
+    public int findFirstCompletelyVisibleItemPosition() {
+        detachStickyHeader();
+        int position = super.findFirstCompletelyVisibleItemPosition();
+        attachStickyHeader();
+        return position;
+    }
+
+    @Override
+    public int findLastVisibleItemPosition() {
+        detachStickyHeader();
+        int position = super.findLastVisibleItemPosition();
+        attachStickyHeader();
+        return position;
+    }
+
+    @Override
+    public int findLastCompletelyVisibleItemPosition() {
+        detachStickyHeader();
+        int position = super.findLastCompletelyVisibleItemPosition();
+        attachStickyHeader();
+        return position;
+    }
+
+    @Override
+    public View onFocusSearchFailed(
+            View focused, int focusDirection, RecyclerView.Recycler recycler, RecyclerView.State state) {
         detachStickyHeader();
         View view = super.onFocusSearchFailed(focused, focusDirection, recycler, state);
         attachStickyHeader();

--- a/StickyHeaders/src/main/java/io/doist/recyclerviewext/sticky_headers/StickyHeadersLinearLayoutManager.java
+++ b/StickyHeaders/src/main/java/io/doist/recyclerviewext/sticky_headers/StickyHeadersLinearLayoutManager.java
@@ -680,34 +680,29 @@ public class StickyHeadersLinearLayoutManager<T extends RecyclerView.Adapter & S
         @Override
         public void onItemRangeMoved(int fromPosition, int toPosition, int itemCount) {
             // Shift moved headers by toPosition - fromPosition.
-            // Shift headers in-between by -itemCount (reverse if upwards).
+            // Shift headers in-between by itemCount (reverse if downwards).
             int headerCount = mHeaderPositions.size();
             if (headerCount > 0) {
-                if (fromPosition < toPosition) {
-                    for (int i = findHeaderIndexOrNext(fromPosition); i != -1 && i < headerCount; i++) {
-                        int headerPos = mHeaderPositions.get(i);
-                        if (headerPos >= fromPosition && headerPos < fromPosition + itemCount) {
-                            mHeaderPositions.set(i, headerPos - (toPosition - fromPosition));
-                            sortHeaderAtIndex(i);
-                        } else if (headerPos >= fromPosition + itemCount && headerPos <= toPosition) {
-                            mHeaderPositions.set(i, headerPos - itemCount);
-                            sortHeaderAtIndex(i);
-                        } else {
-                            break;
-                        }
+                int topPosition = Math.min(fromPosition, toPosition);
+                for (int i = findHeaderIndexOrNext(topPosition); i != -1 && i < headerCount; i++) {
+                    int headerPos = mHeaderPositions.get(i);
+                    int newHeaderPos = headerPos;
+                    if (headerPos >= fromPosition && headerPos < fromPosition + itemCount) {
+                        newHeaderPos += toPosition - fromPosition;
+                    } else if (fromPosition < toPosition
+                            && headerPos >= fromPosition + itemCount && headerPos <= toPosition) {
+                        newHeaderPos -= itemCount;
+                    } else if (fromPosition > toPosition
+                            && headerPos >= toPosition && headerPos <= fromPosition) {
+                        newHeaderPos += itemCount;
+                    } else {
+                        break;
                     }
-                } else {
-                    for (int i = findHeaderIndexOrNext(toPosition); i != -1 && i < headerCount; i++) {
-                        int headerPos = mHeaderPositions.get(i);
-                        if (headerPos >= fromPosition && headerPos < fromPosition + itemCount) {
-                            mHeaderPositions.set(i, headerPos + (toPosition - fromPosition));
-                            sortHeaderAtIndex(i);
-                        } else if (headerPos >= toPosition && headerPos <= fromPosition) {
-                            mHeaderPositions.set(i, headerPos + itemCount);
-                            sortHeaderAtIndex(i);
-                        } else {
-                            break;
-                        }
+                    if (newHeaderPos != headerPos) {
+                        mHeaderPositions.set(i, newHeaderPos);
+                        sortHeaderAtIndex(i);
+                    } else {
+                        break;
                     }
                 }
             }

--- a/StickyHeaders/src/main/java/io/doist/recyclerviewext/sticky_headers/StickyHeadersLinearLayoutManager.java
+++ b/StickyHeaders/src/main/java/io/doist/recyclerviewext/sticky_headers/StickyHeadersLinearLayoutManager.java
@@ -28,8 +28,8 @@ public class StickyHeadersLinearLayoutManager<T extends RecyclerView.Adapter & S
     private float mTranslationY;
 
     // Header positions for the currently displayed list and their observer.
-    private List<Integer> mHeaderPositions = new ArrayList<>(0);
-    private RecyclerView.AdapterDataObserver mHeaderPositionsObserver = new HeaderPositionsAdapterDataObserver();
+    private final List<Integer> mHeaderPositions = new ArrayList<>(0);
+    private final RecyclerView.AdapterDataObserver mHeaderPositionsObserver = new HeaderPositionsAdapterDataObserver();
 
     // Sticky header's ViewHolder and dirty state.
     private View mStickyHeader;
@@ -42,7 +42,8 @@ public class StickyHeadersLinearLayoutManager<T extends RecyclerView.Adapter & S
         super(context);
     }
 
-    public StickyHeadersLinearLayoutManager(Context context, int orientation, boolean reverseLayout) {
+    public StickyHeadersLinearLayoutManager(
+            Context context, @RecyclerView.Orientation int orientation, boolean reverseLayout) {
         super(context, orientation, reverseLayout);
     }
 

--- a/StickyHeaders/src/main/java/io/doist/recyclerviewext/sticky_headers/StickyHeadersLinearLayoutManager.java
+++ b/StickyHeaders/src/main/java/io/doist/recyclerviewext/sticky_headers/StickyHeadersLinearLayoutManager.java
@@ -31,12 +31,15 @@ public class StickyHeadersLinearLayoutManager<T extends RecyclerView.Adapter & S
     private final List<Integer> mHeaderPositions = new ArrayList<>(0);
     private final RecyclerView.AdapterDataObserver mHeaderPositionsObserver = new HeaderPositionsAdapterDataObserver();
 
-    // Sticky header's ViewHolder and dirty state.
+    // ViewHolder and dirty state.
     private View mStickyHeader;
     private int mStickyHeaderPosition = RecyclerView.NO_POSITION;
 
     private int mPendingScrollPosition = RecyclerView.NO_POSITION;
     private int mPendingScrollOffset = 0;
+
+    // Attach count, to ensure the sticky header is only attached and detached when expected.
+    private int mStickyHeaderAttachCount = 0;
 
     public StickyHeadersLinearLayoutManager(Context context) {
         super(context);
@@ -267,13 +270,13 @@ public class StickyHeadersLinearLayoutManager<T extends RecyclerView.Adapter & S
     }
 
     private void detachStickyHeader() {
-        if (mStickyHeader != null) {
+        if (--mStickyHeaderAttachCount == 0 && mStickyHeader != null) {
             detachView(mStickyHeader);
         }
     }
 
     private void attachStickyHeader() {
-        if (mStickyHeader != null) {
+        if (++mStickyHeaderAttachCount == 1 && mStickyHeader != null) {
             attachView(mStickyHeader);
         }
     }
@@ -370,6 +373,7 @@ public class StickyHeadersLinearLayoutManager<T extends RecyclerView.Adapter & S
 
         mStickyHeader = stickyHeader;
         mStickyHeaderPosition = position;
+        mStickyHeaderAttachCount = 1;
     }
 
     /**

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath "com.android.tools.build:gradle:3.5.0"
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-all.zip


### PR DESCRIPTION
This PR enhances `DragDropHelper` to support arbitrary moves, as dictated by its callback. It switches from always working with adjacent positions, to working with any position. For instance, it might ask its callback to move from position 1 to 2, and the callback _can_ decide to move into position 10 instead (or any other, for that matter).

It also contains a couple of unrelated fixes/improvements. Review by commit is recommended.

