### PR TITLE
Investigate crash happens on `Items.add()` invocation

### DIFF
--- a/Animations/src/main/java/io/doist/recyclerviewext/animations/AnimatedAdapter.java
+++ b/Animations/src/main/java/io/doist/recyclerviewext/animations/AnimatedAdapter.java
@@ -1,5 +1,6 @@
 package io.doist.recyclerviewext.animations;
 
+import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
 
 /**
@@ -37,7 +38,7 @@ public abstract class AnimatedAdapter<VH extends RecyclerView.ViewHolder>
      */
     public final void setAnimationsEnabled(boolean enabled) {
         if (enabled && dataSetDiffer == null) {
-            dataSetDiffer = new DataSetDiffer(this, this);
+            dataSetDiffer = new DataSetDiffer(this, this, createAnomalyLogger());
         } else if (!enabled && dataSetDiffer != null) {
             dataSetDiffer.stopObservingItems();
             dataSetDiffer = null;
@@ -56,5 +57,10 @@ public abstract class AnimatedAdapter<VH extends RecyclerView.ViewHolder>
         } else {
             notifyDataSetChanged();
         }
+    }
+
+    @Nullable
+    protected DataSetDiffer.AnomalyLogger createAnomalyLogger() {
+        return null;
     }
 }

--- a/Animations/src/main/java/io/doist/recyclerviewext/animations/AsyncDataSetDiffer.java
+++ b/Animations/src/main/java/io/doist/recyclerviewext/animations/AsyncDataSetDiffer.java
@@ -5,6 +5,7 @@ import android.os.Looper;
 
 import java.util.concurrent.Executor;
 
+import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -29,12 +30,12 @@ public class AsyncDataSetDiffer {
      * @param adapter  Adapter with which this data set differ is associated.
      * @param callback Callback that provides information about the items set in the adapter.
      */
-    public AsyncDataSetDiffer(RecyclerView.Adapter adapter, DataSetDiffer.Callback callback) {
+    public AsyncDataSetDiffer(RecyclerView.Adapter adapter, DataSetDiffer.Callback callback, @Nullable DataSetDiffer.AnomalyLogger logger) {
         if (!adapter.hasStableIds()) {
             adapter.setHasStableIds(true);
         }
         this.adapter = adapter;
-        dataSetDiffer = new DataSetDiffer(adapter, callback);
+        dataSetDiffer = new DataSetDiffer(adapter, callback, logger);
     }
 
     /**

--- a/Animations/src/main/java/io/doist/recyclerviewext/animations/Items.java
+++ b/Animations/src/main/java/io/doist/recyclerviewext/animations/Items.java
@@ -1,10 +1,14 @@
 package io.doist.recyclerviewext.animations;
 
+import java.util.Arrays;
+
+import androidx.annotation.NonNull;
+
 /**
  * Helper class to store and manage arrays of ids and content hashes as efficiently as possible, by storing them
  * contiguously in a single array in the format [id1, contenthash1, id2, contenthash2, ...].
  */
-class Items {
+public class Items {
     private long[] items;
     private int size;
 
@@ -14,6 +18,11 @@ class Items {
 
     public Items(int capacity) {
         items = new long[capacity*2];
+    }
+
+    public Items(@NonNull Items original) {
+        items = Arrays.copyOf(original.items, original.items.length);
+        size = original.size;
     }
 
     public long getId(int index) {
@@ -26,6 +35,11 @@ class Items {
 
     public int size() {
         return size;
+    }
+
+    @NonNull
+    public long[] items() {
+        return items;
     }
 
     public void setId(int index, long id) {


### PR DESCRIPTION
Investigate crash happens on `Items.add()` invocation.

It looks like in some cases `i` is larger than `size`. Reported exception: `ArrayIndexOutOfBoundsException: src.length=6 srcPos=4 dst.length=6 dstPos=6 length=-2` Values decryption: `srcPos = i * 2`, `dstPos = (i + 1) * 2` and `lenght = (size - i) *2`.
So `i = 2`, `items.lenght = 3`, `size = 1`.

That's strange, seems it can be "hot-patched" by using "append"-logic instead of "insert"-one.

In the meantime, we'll try to catch a "rogue" data and make a more robust fix based of it.

Notes:
- `Items.contentToString()` is limited to `512` array length (`2 * size`). It's a magic number required because according to the reports there can be more than 1k elements.
- `logger` isn't required because most of crashes related to a few adapters. That allows to reduce affected area in `Todoist`.
- `logger` reports only once and with the initial data, because `diffDataSet` looks like a pure function. We should be able to restore all steps based on the state (`original`) and incoming changes (`update`).

Ref:
- https://console.firebase.google.com/u/1/project/td-project-01/crashlytics/app/android:com.todoist/issues/5c9428c4f8b88c296305cb0b