### PR TITLE
Compare list object instances when diffing data sets

### DIFF
--- a/Animations/src/main/java/io/doist/recyclerviewext/animations/AnimatedAdapter.java
+++ b/Animations/src/main/java/io/doist/recyclerviewext/animations/AnimatedAdapter.java
@@ -45,14 +45,20 @@ public abstract class AnimatedAdapter<VH extends RecyclerView.ViewHolder>
     }
 
     /**
-     * Analyzes the data set using {@link #getItemId(int)} and {@link #getItemContentHash(int)} and calls the
-     * necessary {@code notify*} methods to go from the previous data set to the new one.
-     *
+     * @deprecated Use {@link #animateDataSetChanged(Object, Object)}.
+     * It fixes cases when the list instance is changed but the contents are the same.
+     */
+    @Deprecated
+    public void animateDataSetChanged() {
+        animateDataSetChanged(null, null);
+    }
+
+    /**
      * This method should be called right after the data set is updated.
      */
-    public void animateDataSetChanged() {
+    public void animateDataSetChanged(Object oldListObj, Object newListObj) {
         if (areAnimationsEnabled()) {
-            dataSetDiffer.diffDataSet();
+            dataSetDiffer.diffDataSet(oldListObj, newListObj);
         } else {
             notifyDataSetChanged();
         }

--- a/Animations/src/main/java/io/doist/recyclerviewext/animations/DataSetDiffer.java
+++ b/Animations/src/main/java/io/doist/recyclerviewext/animations/DataSetDiffer.java
@@ -36,18 +36,18 @@ public class DataSetDiffer {
      * Analyzes the data set using the supplied {@link Callback} and triggers all necessary {@code notify*} calls.
      */
     @UiThread
-    public void diffDataSet() {
+    public void diffDataSet(Object oldListObj, Object newListObj) {
         // Pause adapter monitoring to avoid double counting changes.
         stopObservingItems();
 
         // Diff data set using the default diff handler and callback.
-        diffDataSet(adapterNotifyDiffHandler, callback);
+        diffDataSet(oldListObj, newListObj, adapterNotifyDiffHandler, callback);
 
         // Resume adapter monitoring.
         startObservingItems();
     }
 
-    void diffDataSet(DiffHandler diffHandler, Callback callback) {
+    void diffDataSet(Object oldListObj, Object newListObj, DiffHandler diffHandler, Callback callback) {
         // Prepare adapter items.
         int itemCount = callback.getItemCount();
         Items adapterItems = new Items(itemCount);
@@ -157,6 +157,13 @@ public class DataSetDiffer {
         }
         if (insertPosition != -1) {
             diffHandler.onItemRangeInserted(insertPosition, insertCount);
+        }
+
+        // When there are no data changes but the backing list instance has changed.
+        if (removeCount == 0 && changeCount == 0 && insertCount == 0) {
+            if (oldListObj != newListObj) {
+                diffHandler.onItemRangeChanged(0, itemCount);
+            }
         }
     }
 


### PR DESCRIPTION
This PR adds handling of the case where the backing list instance changes but the contents remain the same (based on their IDs and content hash). When this happens, `onBindViewHolder` doesn't get called for the items, which causes the ViewHolder to have reference to a stale instance.

This can cause some inconsistencies when mutating items in some cases.