### PR TITLE
Fix crash with null view

### DIFF
--- a/StickyHeaders/src/main/java/io/doist/recyclerviewext/sticky_headers/StickyHeadersLinearLayoutManager.java
+++ b/StickyHeaders/src/main/java/io/doist/recyclerviewext/sticky_headers/StickyHeadersLinearLayoutManager.java
@@ -426,7 +426,9 @@ public class StickyHeadersLinearLayoutManager<T extends RecyclerView.Adapter & S
             mStickyHeader.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
                 @Override
                 public void onGlobalLayout() {
-                    mStickyHeader.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                    if (mStickyHeader != null) {
+                        mStickyHeader.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                    }
 
                     if (mPendingScrollPosition != RecyclerView.NO_POSITION) {
                         scrollToPositionWithOffset(mPendingScrollPosition, mPendingScrollOffset);


### PR DESCRIPTION
Fixes crash 

```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'android.view.ViewTreeObserver android.view.View.getViewTreeObserver()' on a null object reference
       at io.doist.recyclerviewext.sticky_headers.StickyHeadersLinearLayoutManager$1.onGlobalLayout(StickyHeadersLinearLayoutManager.java:429)
       at android.view.ViewTreeObserver.dispatchOnGlobalLayout(ViewTreeObserver.java:959)
       at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:2873)
       at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1873)
       at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:8478)
       at android.view.Choreographer$CallbackRecord.run(Choreographer.java:949)
       at android.view.Choreographer.doCallbacks(Choreographer.java:761)
       at android.view.Choreographer.doFrame(Choreographer.java:696)
       at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:935)
       at android.os.Handler.handleCallback(Handler.java:873)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loop(Looper.java:214)
       at android.app.ActivityThread.main(ActivityThread.java:6986)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:494)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1445)
```